### PR TITLE
Add python 3.14 in the matrix and update to the latests pins

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.8"
           python-version: "3.13"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,18 +23,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.9.15"
-          python-version: "3.12"
+          version: "0.11.8"
+          python-version: "3.13"
       - name: Sync docs extras
         run: uv sync --frozen --extra docs
       - name: Build site
         run: uv run --frozen --no-sync zensical build --strict
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -46,4 +46,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.8"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
+        with:
+          version: "0.11.8"
 
       - name: Install Python
         run: uv python install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.8"
           python-version: ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.8"
           python-version: "3.13"
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.8"
           python-version: "3.13"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.9.15"
+          version: "0.11.8"
           python-version: ${{ matrix.python-version }}
       - name: Sync dependencies
         # The api extras are required because tests/api/ imports
@@ -34,24 +34,24 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.9.15"
-          python-version: "3.12"
+          version: "0.11.8"
+          python-version: "3.13"
       - name: Run ruff check
         run: uvx ruff check src/ tests/ --output-format=github
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.9.15"
-          python-version: "3.12"
+          version: "0.11.8"
+          python-version: "3.13"
       - name: Sync dev + api extras
         run: uv sync --frozen --extra dev --extra api
       - name: Run tests with coverage
@@ -60,7 +60,7 @@ jobs:
         run: uv run --frozen --no-sync pytest tests/ --cov --cov-report=term-missing --cov-report=xml
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-xml
           path: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ between minor versions.
 
 ## [Unreleased]
 
+### Added
+
+- **Python 3.14 added to the supported version matrix.** CI now exercises
+  3.10, 3.11, 3.12, 3.13, and 3.14 on every push, and the PyPI
+  `Programming Language :: Python :: 3.14` classifier advertises the new
+  ceiling on `pypi.org/project/fastssv`. Python 3.14 went stable on
+  2025-10-07; with `requires-python = ">=3.10"` already covering it, the
+  only remaining gaps were test coverage and the published metadata, both
+  of which this change closes. No source or dependency changes were
+  required — `sqlglot` and the rest of the runtime tree already resolve
+  on 3.14.
+
 ### Changed
 
 - **Pre-commit configuration migrated from `.pre-commit-config.yaml` to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3.13",
+	"Programming Language :: Python :: 3.14",
 	"Topic :: Database",
 	"Topic :: Software Development :: Quality Assurance",
 ]


### PR DESCRIPTION
- Add Python 3.14 to the tests.yml matrix (now 3.10–3.14).
- Bump pinned tool versions across all three workflows to the current latest releases (actions/checkout v4 → v6, astral-sh/setup-uv v7 → v8, uv 0.9.15. → 0.11.8, actions/upload-artifact v4 → v7, GitHub Pages actions configure-pages v5 → v6, upload-pages-artifact v3 → v5, deploy-pages v4 → v5).
- Pin setup-uv to version: "0.11.8" in publish.yml (was unpinned, so it silently tracked the action default, now matches tests.yml / docs.yml).