### PR TITLE
Feat/ss mcp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,76 @@
-# FastSSV Configuration
-# Copy this file to .env and replace with your actual values
+# FastSSV — local-development configuration template.
+#
+# Copy this file to `.env` (which is gitignored) and edit values you care about:
+#   cp .env.example .env
+#
+# `pydantic-settings` automatically loads `.env` from the working directory
+# when fastssv boots (see src/fastssv/api/config.py:13). Run any of these
+# from this directory and the values flow in:
+#   uv run --frozen --no-sync fastssv path/to/query.sql
+#   uv run --frozen --no-sync fastssv serve --reload
+#
+# For Docker / compose deployments use deploy/.env.example instead — that
+# template adds compose-only knobs (FASTSSV_PORT, WEB_CONCURRENCY) that are
+# meaningless when running fastssv directly.
 
 # =============================================================================
-# Logging Configuration
+# CLI logging (read by fastssv.core.logging — applies to `fastssv path/...`)
 # =============================================================================
 
-# Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-# Default: INFO
+# Log level. One of DEBUG / INFO / WARNING / ERROR / CRITICAL.
 FASTSSV_LOG_LEVEL=INFO
 
-# Log file path (optional - if not set, logs to console only)
-# Example: FASTSSV_LOG_FILE=logs/fastssv.log
-# FASTSSV_LOG_FILE=
+# Optional: write logs to a file in addition to the console.
+# FASTSSV_LOG_FILE=logs/fastssv.log
 
-# Log format (simple, detailed, json)
-# - simple: Just level and message
-# - detailed: Timestamp, logger name, level, and message (default)
-# - json: Structured JSON logs for machine parsing
-# Default: detailed
+# Log format. One of: simple, detailed, json.
 FASTSSV_LOG_FORMAT=detailed
 
 # =============================================================================
-# Langfuse Configuration (Optional)
+# API service (read by fastssv.api.config.Settings — applies to `fastssv serve`)
 # =============================================================================
+# Note the prefix difference: CLI vars are FASTSSV_*, API vars are FASTSSV_API_*.
 
-# Langfuse API credentials for telemetry tracking
-# LANGFUSE_SECRET_KEY=your_secret_key_here
-# LANGFUSE_PUBLIC_KEY=your_public_key_here
-# LANGFUSE_HOST=https://cloud.langfuse.com
+# Log level for the FastAPI app. Independent of FASTSSV_LOG_LEVEL above.
+FASTSSV_API_LOG_LEVEL=INFO
+
+# Per-IP rate limit. Format: "<count>/<window>". Examples: 60/minute, 1000/hour.
+FASTSSV_API_RATE_LIMIT=60/minute
+
+# Max bytes accepted for a single SQL submission. Requests exceeding this
+# are rejected with HTTP 413 by the body-size middleware before parsing.
+FASTSSV_API_MAX_SQL_BYTES=100000
+
+# Wall-clock timeout for sqlglot parsing of a single submission, in seconds.
+FASTSSV_API_PARSE_TIMEOUT_SECONDS=5
+
+# Comma-separated allowlist of CORS origins for the JSON API. Empty = no
+# cross-origin browser requests accepted.
+FASTSSV_API_CORS_ORIGINS=
+
+# Trust X-Forwarded-* headers from a reverse proxy. Set to true when
+# running behind nginx/Caddy/Traefik/Cloudflare terminating TLS upstream.
+FASTSSV_API_BEHIND_PROXY=false
+
+# =============================================================================
+# MCP (Model Context Protocol) — Streamable HTTP endpoint at /mcp
+# =============================================================================
+# Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+#
+# OPT-IN by default: the endpoint is unauthenticated at the application
+# layer. Only enable when you've thought about who can reach this fastssv
+# instance. For local dev that means "you and anything running on your
+# machine"; for deployed environments that means "put a reverse proxy with
+# auth in front first." See docs/mcp.md for the full posture.
+
+# Mount the /mcp endpoint. Requires the [mcp] extra to be installed
+# (pip install "fastssv[api,mcp]").
+FASTSSV_API_MCP_ENABLED=false
+
+# Comma-separated allowlist of Origins permitted to hit /mcp from a browser.
+# Spec MUST: servers validate the Origin header to prevent DNS rebinding
+# attacks. Requests with no Origin header (curl, Claude Desktop, MCP
+# Inspector running outside a browser) always pass through. Requests with
+# a present-but-unlisted Origin are rejected with HTTP 403.
+# Example: FASTSSV_API_MCP_ALLOWED_ORIGINS=https://chat.example.com
+FASTSSV_API_MCP_ALLOWED_ORIGINS=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,11 +93,12 @@ For every kind of change, before reporting done:
 ## Conventions
 
 - **`uv sync` / `uv add` only — never `uv pip install`.** CI and Docker use `uv sync --frozen`; `uv pip` is a compat shim.
+- **End-user docs are uv-native too** — `README.md`, `docs/index.md`, `docs/api.md`, `docs/mcp.md`, `docs/plugin_architecture.md` use `uv add "fastssv[…]"` + `uv run fastssv …` for install + run examples. No `pip install`, no `uv tool install` (global PATH), no `uv pip install` (compat shim). Historical `CHANGELOG.md` entries describing earlier releases keep their original wording — don't rewrite history.
 - Edit existing files over creating new ones.
 - `[project.optional-dependencies]` extras grouped: `dev`, `docs`, `api`, `mcp`. New optional groups go alongside.
 - The `[api]` extra uses `fastapi[standard]`, which transitively pulls `uvicorn[standard]`, `jinja2`, `python-multipart`, and `httpx`. Don't re-add those at the top level — let FastAPI manage them. Only add deps FastAPI doesn't pull in (current additions: `gunicorn`, `slowapi`, `pydantic-settings`).
 - The API's `cors_origins` setting accepts an empty string, a comma-separated list, or a JSON list (see the `field_validator` in `src/fastssv/api/config.py`). Don't undo that tolerance — `pydantic-settings>=2` would otherwise crash on the empty-string default that `deploy/docker-compose.yml` passes through. The same `_parse_origin_list` validator is reused for `mcp_allowed_origins`.
-- The `[mcp]` extra is independent of `[api]`; the MCP server is mounted by `api/app.py` only when both `mcp_enabled=True` and the `mcp` package import succeeds. Without the extra, the app logs `mcp_extra_not_installed` and runs without the `/mcp` mount — never let that path raise.
+- The `[mcp]` extra is independent of `[api]`. The MCP server is mounted by `api/app.py` only when `settings.mcp_enabled=True` AND the `mcp` package imports successfully. If the operator opts in (`FASTSSV_API_MCP_ENABLED=true`) but the extra isn't installed, `_maybe_build_mcp_app` raises `RuntimeError` at startup so the misconfiguration fails loudly in non-interactive deployments (CI/docker) instead of silently booting without `/mcp`. Don't revert that to a warning-and-skip path. Regression guard: `tests/api/test_mcp.py::test_mcp_enabled_but_extra_missing_raises`.
 - Middleware ordering in `api/app.py` is load-bearing: `MCPOriginMiddleware` short-circuits with a 403 on disallowed Origins, so it MUST be registered *before* (and therefore inside) `SecurityHeadersMiddleware` and `RequestIDMiddleware` so those wrap the rejection response. There's a regression test in `tests/api/test_mcp.py::test_origin_disallowed_returns_403`.
 
 ## Cross-tool layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ A static, semantic validator for SQL written against the [OMOP CDM v5.4](https:/
 `requires-python = ">=3.10"`. The project uses **uv** end-to-end ([install](https://docs.astral.sh/uv/getting-started/installation/)):
 
 ```sh
-uv sync --frozen --extra dev --extra api    # full dev env
-uv sync --frozen --extra docs               # docs work
+uv sync --frozen --extra dev --extra api --extra mcp  # full dev env (API + MCP)
+uv sync --frozen --extra docs                         # docs work
 ```
 
 ## Commands
@@ -38,13 +38,17 @@ uv sync --frozen --extra docs               # docs work
 
 ```
 src/fastssv/
-  api/                FastAPI service ([api] extra) — Jinja templates, htmx UI
+  api/                FastAPI service ([api] extra) — Jinja templates, htmx UI;
+                      api/_validation.py is the shared statement-split + strict +
+                      timeout helper used by both /v1/validate and the MCP tool
+  mcp/                MCP Streamable HTTP server ([mcp] extra) — mounted by
+                      api/app.py at /mcp; one tool (validate_sql)
   core/               base Rule, registry, helpers
   rules/<category>/   validation rules; one rule per file, self-registering
   schemas/            OMOP CDM column types and standard-concept field set
 tests/                pytest (unit + api integration); rule tests in tests/test_rules.py
 docs/                 zensical source (zensical.toml at repo root)
-deploy/               Dockerfile + docker-compose for the API
+deploy/               Dockerfile + docker-compose for the API + MCP endpoint
 .github/workflows/    tests.yml, docs.yml, publish.yml
 .agents/              shared agent assets (skills, prompts) — see Cross-tool layout
 ```
@@ -84,15 +88,17 @@ For every kind of change, before reporting done:
 
 1. **Sweep for stale references.** Whenever you rename or remove a public symbol, `rule_id`, severity, exception, CLI flag, command, dependency, config key, file, or feature — grep the whole tree and update every hit. Cover `src/`, `tests/`, `scripts/`, `examples/`, `docs/`, `README.md`, `## [Unreleased]` in `CHANGELOG.md`, `AGENTS.md` (and the `CLAUDE.md` symlink), `.github/workflows/`, `deploy/Dockerfile`, `deploy/docker-compose.yml`. Same applies to behaviour changes that don't rename anything: walk every caller, comment, docstring, and test still describing the old contract. Stale references rot silently.
 2. **Run pre-commit hooks**: `uvx prek run --all-files` (or `uvx prek run` for staged files). [Prek](https://github.com/j178/prek) reads [`prek.toml`](https://prek.j178.dev/configuration/) — trailing whitespace, EOL, YAML/TOML validity, merge markers, large-file guard, `ruff check --fix`, `ruff format`. Fix anything flagged.
-3. **Verify end-to-end — backend AND frontend.** Green `pytest` is necessary but not sufficient: the API web UI (`src/fastssv/api/ui.py`, Jinja templates under `src/fastssv/api/templates/`, htmx + CSS under `src/fastssv/api/static/`) only has thin smoke tests. For changes touching `src/fastssv/api/`, dependencies, the deploy bundle, or anything that could affect request handling or asset serving — boot locally with `uv run --frozen --no-sync fastssv serve --reload` and click through index, rules listing, and a sample SQL validation. If you can't verify the UI, say so explicitly in the handoff.
+3. **Verify end-to-end — backend AND frontend.** Green `pytest` is necessary but not sufficient: the API web UI (`src/fastssv/api/ui.py`, Jinja templates under `src/fastssv/api/templates/`, htmx + CSS under `src/fastssv/api/static/`) only has thin smoke tests. For changes touching `src/fastssv/api/`, `src/fastssv/mcp/`, dependencies, the deploy bundle, or anything that could affect request handling or asset serving — boot locally with `uv run --frozen --no-sync fastssv serve --reload` and click through index, rules listing, and a sample SQL validation. For MCP changes also `curl -X POST http://localhost:8000/mcp/ -H 'Accept: application/json, text/event-stream' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"c","version":"0"}}}'` and confirm a 200 with `serverInfo.name=fastssv` (the `/mcp` mount is a Starlette sub-app and does NOT appear in `/openapi.json` or `/docs` — that's expected). If you can't verify the UI, say so explicitly in the handoff.
 
 ## Conventions
 
 - **`uv sync` / `uv add` only — never `uv pip install`.** CI and Docker use `uv sync --frozen`; `uv pip` is a compat shim.
 - Edit existing files over creating new ones.
-- `[project.optional-dependencies]` extras grouped: `dev`, `docs`, `api`. New optional groups go alongside.
+- `[project.optional-dependencies]` extras grouped: `dev`, `docs`, `api`, `mcp`. New optional groups go alongside.
 - The `[api]` extra uses `fastapi[standard]`, which transitively pulls `uvicorn[standard]`, `jinja2`, `python-multipart`, and `httpx`. Don't re-add those at the top level — let FastAPI manage them. Only add deps FastAPI doesn't pull in (current additions: `gunicorn`, `slowapi`, `pydantic-settings`).
-- The API's `cors_origins` setting accepts an empty string, a comma-separated list, or a JSON list (see the `field_validator` in `src/fastssv/api/config.py`). Don't undo that tolerance — `pydantic-settings>=2` would otherwise crash on the empty-string default that `deploy/docker-compose.yml` passes through.
+- The API's `cors_origins` setting accepts an empty string, a comma-separated list, or a JSON list (see the `field_validator` in `src/fastssv/api/config.py`). Don't undo that tolerance — `pydantic-settings>=2` would otherwise crash on the empty-string default that `deploy/docker-compose.yml` passes through. The same `_parse_origin_list` validator is reused for `mcp_allowed_origins`.
+- The `[mcp]` extra is independent of `[api]`; the MCP server is mounted by `api/app.py` only when both `mcp_enabled=True` and the `mcp` package import succeeds. Without the extra, the app logs `mcp_extra_not_installed` and runs without the `/mcp` mount — never let that path raise.
+- Middleware ordering in `api/app.py` is load-bearing: `MCPOriginMiddleware` short-circuits with a 403 on disallowed Origins, so it MUST be registered *before* (and therefore inside) `SecurityHeadersMiddleware` and `RequestIDMiddleware` so those wrap the rejection response. There's a regression test in `tests/api/test_mcp.py::test_origin_disallowed_returns_403`.
 
 ## Cross-tool layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,14 @@ between minor versions.
   `validate_sql` results). The endpoint is built per the
   [2025-11-25 spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
   in stateless mode (`stateless_http=True`, `json_response=True`), so no
-  session store or SSE resumption layer is required. New env vars under
-  the `FASTSSV_API_` prefix: `MCP_ENABLED` (default `false` — opt-in
-  because the endpoint is unauthenticated at the application layer),
-  `MCP_ALLOWED_ORIGINS` (CSV/JSON list, enforced by a dedicated
+  session store or SSE resumption layer is required. New env vars:
+  `FASTSSV_API_MCP_ENABLED` (default `false` — opt-in because the endpoint
+  is unauthenticated at the application layer),
+  `FASTSSV_API_MCP_ALLOWED_ORIGINS` (CSV/JSON list, enforced by a dedicated
   middleware that 403s requests with a present-but-unlisted `Origin` —
-  per the spec's DNS-rebinding mitigation), and `MCP_AUTH_MODE` (reserved
-  Literal pinned to `"none"`; widening it later is how we'd opt into
-  OAuth 2.1 without churning the env-var name). **Authentication is
+  per the spec's DNS-rebinding mitigation), and `FASTSSV_API_MCP_AUTH_MODE`
+  (reserved Literal pinned to `"none"`; widening it later is how we'd opt
+  into OAuth 2.1 without churning the env-var name). **Authentication is
   intentionally unauthenticated at the application layer** — the [MCP
   authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
   is OPTIONAL, and FastSSV's stateless validation surface has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ between minor versions.
 
 ## [Unreleased]
 
+### Added
+
+- **MCP (Model Context Protocol) Streamable HTTP endpoint at `/mcp`.** A
+  new optional `[mcp]` extra (`uv add fastssv[mcp]`) brings in the
+  official `mcp` Python SDK and mounts a stateless Streamable HTTP server
+  alongside the existing FastAPI app. One tool is exposed: `validate_sql`
+  (wraps `validate_sql_structured` with the same statement-split, strict
+  mode and timeout behaviour as `/v1/validate`). Rule discovery happens
+  via the `rule_id` returned on each violation, or the existing
+  `/v1/rules` HTTP endpoint and `docs/rules_reference.md` — there is no
+  separate `list_rules` MCP tool, since a static catalog is a poor fit
+  for the tool primitive (it's the wrong primitive — resources would be
+  better — and the `rule_id`s the model needs are surfaced in
+  `validate_sql` results). The endpoint is built per the
+  [2025-11-25 spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
+  in stateless mode (`stateless_http=True`, `json_response=True`), so no
+  session store or SSE resumption layer is required. New env vars under
+  the `FASTSSV_API_` prefix: `MCP_ENABLED` (default `false` — opt-in
+  because the endpoint is unauthenticated at the application layer),
+  `MCP_ALLOWED_ORIGINS` (CSV/JSON list, enforced by a dedicated
+  middleware that 403s requests with a present-but-unlisted `Origin` —
+  per the spec's DNS-rebinding mitigation), and `MCP_AUTH_MODE` (reserved
+  Literal pinned to `"none"`; widening it later is how we'd opt into
+  OAuth 2.1 without churning the env-var name). **Authentication is
+  intentionally unauthenticated at the application layer** — the [MCP
+  authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+  is OPTIONAL, and FastSSV's stateless validation surface has no
+  per-user resources, so the deployment expectation is that operators
+  gate `/mcp` at the reverse proxy (oauth2-proxy, mTLS, network ACLs).
+  The `[mcp]` extra is added to `deploy/Dockerfile` and the new env vars
+  are wired through `deploy/docker-compose.yml` and `deploy/.env.example`.
+  When the `mcp` package is missing at runtime the app logs a warning
+  and skips the mount, so an `[api]`-only install still works.
+
 ### Changed
 
 - **`parse_sql` is now `lru_cache`-d on `(sql, dialect)`.** A single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,17 @@ between minor versions.
 
 ### Fixed
 
+- **`deploy/.env.example` documents `FASTSSV_API_BEHIND_PROXY`.** The
+  reverse-proxy toggle added with HTTPS support is wired through
+  `deploy/docker-compose.yml` (compose-level default `true`) and read by
+  `Settings.behind_proxy` in `src/fastssv/api/config.py` (in-code default
+  `false`), but it was missing from `deploy/.env.example`. Operators
+  copying the example file as a config reference now see the variable,
+  what it does (trust `X-Forwarded-*` from an upstream TLS terminator so
+  generated URLs reflect the external scheme/host), and the
+  compose-vs-code default split. No behaviour change — purely a
+  documentation gap fix.
+
 - **Documentation correctness pass.** Multiple doc pages had drifted from the
   registry and the API surface; fixes applied across `docs/`:
   - **Severities corrected** for `concept_standardization.standard_concept_enforcement`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,12 @@ between minor versions.
   gate `/mcp` at the reverse proxy (oauth2-proxy, mTLS, network ACLs).
   The `[mcp]` extra is added to `deploy/Dockerfile` and the new env vars
   are wired through `deploy/docker-compose.yml` and `deploy/.env.example`.
-  When the `mcp` package is missing at runtime the app logs a warning
-  and skips the mount, so an `[api]`-only install still works.
+  When `FASTSSV_API_MCP_ENABLED=true` but the `mcp` package is missing,
+  `_maybe_build_mcp_app` raises `RuntimeError` at startup so the
+  misconfiguration fails loudly in non-interactive deployments (CI,
+  docker) instead of silently booting without `/mcp`. With the toggle
+  off (the default) and the `mcp` package missing, the app boots
+  normally — `[api]`-only installs still work.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ fastssv serve              # http://localhost:8000 — JSON API + HTMX web UI
 
 The service ships body-size limits, parse-timeout, rate limiting, strict CORS, security headers, structured JSON logging, and a Docker image under `deploy/`. See the [HTTP API guide](docs/api.md) for endpoints, configuration, and deployment.
 
+## MCP server (optional)
+
+```bash
+pip install "fastssv[api,mcp]"
+FASTSSV_API_MCP_ENABLED=true fastssv serve   # MCP Streamable HTTP endpoint at http://localhost:8000/mcp/
+```
+
+The MCP endpoint is opt-in (`FASTSSV_API_MCP_ENABLED` defaults to `false`) because it's unauthenticated at the application layer.
+
+Mounted at `/mcp` and built per the [Streamable HTTP transport spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http) in stateless mode. One tool: `validate_sql`. The endpoint is unauthenticated at the application layer ([authorization is OPTIONAL in MCP](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)) — gate it at your reverse proxy. See [docs/mcp.md](docs/mcp.md).
+
 ## Documentation
 
 | Topic | Page |
@@ -127,6 +138,7 @@ The service ships body-size limits, parse-timeout, rate limiting, strict CORS, s
 | Reasoning behind each rule category | [docs/semantic_rules_guide.md](docs/semantic_rules_guide.md) |
 | Per-rule catalog (all 154) | [docs/rules_reference.md](docs/rules_reference.md) |
 | HTTP API | [docs/api.md](docs/api.md) |
+| MCP server | [docs/mcp.md](docs/mcp.md) |
 | JSON report format | [docs/json_output.md](docs/json_output.md) |
 | Logging | [docs/logging.md](docs/logging.md) |
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,20 @@ A query that silently drops 30% of patients because it misses concept descendant
 
 ## Install
 
+> Don't have uv yet? [Install it first](https://docs.astral.sh/uv/getting-started/installation/) — one command, no admin rights needed.
+
+From inside a [uv project](https://docs.astral.sh/uv/concepts/projects/) (run `uv init` first if you don't have one):
+
 ```bash
-pip install fastssv
+uv add fastssv
 ```
 
 ## Use it
 
 ```bash
-fastssv path/to/query.sql                       # writes output/validation_report.json
-fastssv path/to/query.sql --strict              # cohort-grade enforcement
-fastssv path/to/query.sql --dialect bigquery    # auto, postgres, tsql, oracle, redshift, bigquery, snowflake, databricks, duckdb
+uv run fastssv path/to/query.sql                       # writes output/validation_report.json
+uv run fastssv path/to/query.sql --strict              # cohort-grade enforcement
+uv run fastssv path/to/query.sql --dialect bigquery    # auto, postgres, tsql, oracle, redshift, bigquery, snowflake, databricks, duckdb
 ```
 
 ```python
@@ -51,7 +55,7 @@ JOIN concept c ON de.drug_concept_id = c.concept_id
 WHERE c.concept_name LIKE '%aspirin%';
 ```
 
-`fastssv query.sql` writes `output/validation_report.json`:
+`uv run fastssv query.sql` writes `output/validation_report.json`:
 
 ```json
 {
@@ -112,8 +116,8 @@ FastSSV validates what other OHDSI tools assume to be correct — the SQL logic 
 ## HTTP API (optional)
 
 ```bash
-pip install "fastssv[api]"
-fastssv serve              # http://localhost:8000 — JSON API + HTMX web UI
+uv add "fastssv[api]"
+uv run fastssv serve       # http://localhost:8000 — JSON API + HTMX web UI
 ```
 
 The service ships body-size limits, parse-timeout, rate limiting, strict CORS, security headers, structured JSON logging, and a Docker image under `deploy/`. See the [HTTP API guide](docs/api.md) for endpoints, configuration, and deployment.
@@ -121,8 +125,8 @@ The service ships body-size limits, parse-timeout, rate limiting, strict CORS, s
 ## MCP server (optional)
 
 ```bash
-pip install "fastssv[api,mcp]"
-FASTSSV_API_MCP_ENABLED=true fastssv serve   # MCP Streamable HTTP endpoint at http://localhost:8000/mcp/
+uv add "fastssv[api,mcp]"
+FASTSSV_API_MCP_ENABLED=true uv run fastssv serve   # MCP Streamable HTTP endpoint at http://localhost:8000/mcp/
 ```
 
 The MCP endpoint is opt-in (`FASTSSV_API_MCP_ENABLED` defaults to `false`) because it's unauthenticated at the application layer.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -51,4 +51,24 @@ FASTSSV_API_CORS_ORIGINS=
 # URLs reflect the external https scheme/host. Disable if exposing the
 # container directly to clients. The compose file defaults this to "true";
 # the in-code default (when running outside compose) is "false".
-FASTSSV_API_BEHIND_PROXY=true
+FASTSSV_API_BEHIND_PROXY=false
+
+# -----------------------------------------------------------------------------
+# MCP (Model Context Protocol) Streamable HTTP endpoint at /mcp
+# -----------------------------------------------------------------------------
+# Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+#
+# Authentication: the MCP endpoint is intentionally unauthenticated at the
+# application layer — gate it at your reverse proxy (oauth2-proxy, mTLS,
+# network ACLs, Cloudflare Access, ...). Auth is OPTIONAL per the MCP spec.
+
+# Enable the /mcp mount. Requires the [mcp] extra to be installed.
+FASTSSV_API_MCP_ENABLED=true
+
+# Comma-separated allowlist of Origins permitted to hit /mcp from a browser.
+# Spec MUST: servers validate the Origin header to prevent DNS rebinding
+# attacks. Requests without an Origin header (curl, Claude Desktop, MCP
+# Inspector running outside a browser) are always allowed. Requests with
+# a present-but-unlisted Origin are rejected with 403.
+# Example: FASTSSV_API_MCP_ALLOWED_ORIGINS=https://chat.example.com
+FASTSSV_API_MCP_ALLOWED_ORIGINS=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -45,3 +45,10 @@ FASTSSV_API_PARSE_TIMEOUT_SECONDS=5
 # For the HTMX UI served by the same app, same-origin requests work without CORS.
 # Example: FASTSSV_API_CORS_ORIGINS=https://example.com,https://staging.example.com
 FASTSSV_API_CORS_ORIGINS=
+
+# Trust X-Forwarded-* headers from a reverse proxy (e.g. nginx, Traefik, Caddy)
+# in front of the container. Enable when terminating TLS upstream so generated
+# URLs reflect the external https scheme/host. Disable if exposing the
+# container directly to clients. The compose file defaults this to "true";
+# the in-code default (when running outside compose) is "false".
+FASTSSV_API_BEHIND_PROXY=true

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -63,7 +63,7 @@ FASTSSV_API_BEHIND_PROXY=false
 # network ACLs, Cloudflare Access, ...). Auth is OPTIONAL per the MCP spec.
 
 # Enable the /mcp mount. Requires the [mcp] extra to be installed.
-FASTSSV_API_MCP_ENABLED=true
+FASTSSV_API_MCP_ENABLED=false
 
 # Comma-separated allowlist of Origins permitted to hit /mcp from a browser.
 # Spec MUST: servers validate the Origin header to prevent DNS rebinding

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,14 +18,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=README.md,target=README.md \
-    uv sync --frozen --no-install-project --extra api
+    uv sync --frozen --no-install-project --extra api --extra mcp
 
 COPY pyproject.toml README.md LICENSE uv.lock ./
 COPY src ./src
 
 # Project layer: install fastssv itself non-editably for a slim image.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-editable --extra api
+    uv sync --frozen --no-editable --extra api --extra mcp
 
 
 FROM python:3.12-slim AS runtime

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,7 +11,11 @@ services:
       context: ..
       dockerfile: deploy/Dockerfile
     image: fastssv:local
-    container_name: fastssv
+    # No container_name on purpose: hardcoding it forces every parallel
+    # `docker compose up` (e.g. tests/api/test_docker_smoke.py with -p
+    # fastssv-smoke) to collide with whatever container is already running
+    # under that name. Compose will derive `<project>-fastssv-1` from the
+    # project name instead, which keeps parallel projects isolated.
     ports:
       - "${FASTSSV_PORT:-8000}:8000"
     environment:
@@ -21,6 +25,8 @@ services:
       FASTSSV_API_PARSE_TIMEOUT_SECONDS: "${FASTSSV_API_PARSE_TIMEOUT_SECONDS:-5}"
       FASTSSV_API_CORS_ORIGINS: "${FASTSSV_API_CORS_ORIGINS:-}"
       FASTSSV_API_BEHIND_PROXY: "${FASTSSV_API_BEHIND_PROXY:-true}"
+      FASTSSV_API_MCP_ENABLED: "${FASTSSV_API_MCP_ENABLED:-false}"
+      FASTSSV_API_MCP_ALLOWED_ORIGINS: "${FASTSSV_API_MCP_ALLOWED_ORIGINS:-}"
       WEB_CONCURRENCY: "${WEB_CONCURRENCY:-2}"
     restart: unless-stopped
     healthcheck:

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,8 @@ Under the hood: dev mode invokes `uvicorn.run(...)` in-process; `--prod` execs
 `gunicorn -k uvicorn.workers.UvicornWorker ...`. Each worker loads the full
 rule registry once at startup (~154 rules, sub-second).
 
+The same process also exposes an MCP Streamable HTTP endpoint at `/mcp` when the optional `[mcp]` extra is installed (`pip install "fastssv[api,mcp]"`). See [MCP server](mcp.md) for tool surface, auth posture, and client setup.
+
 ### `docker compose up` — containerized
 
 Use this for servers, CI, or when you want container isolation to match
@@ -66,6 +68,10 @@ prefix. Defaults are production-sane.
 | `FASTSSV_API_RATE_LIMIT` | `60/minute` | `slowapi`-format limit applied per client IP. |
 | `FASTSSV_API_CORS_ORIGINS` | `[]` | Comma-separated list of allowed origins. Empty = CORS disabled. |
 | `FASTSSV_API_LOG_LEVEL` | `INFO` | Root logger level (`DEBUG`/`INFO`/`WARNING`/`ERROR`). |
+| `FASTSSV_API_BEHIND_PROXY` | `false` | Trust `X-Forwarded-*` headers from a reverse proxy. The compose file defaults this to `true`; in-code default is `false` for direct execution. |
+| `FASTSSV_API_MCP_ENABLED` | `false` | Mount the MCP Streamable HTTP endpoint at `/mcp` (requires the `[mcp]` extra). Opt-in because the endpoint is unauthenticated at the app layer; gate it at your reverse proxy before enabling. See [MCP server](mcp.md). |
+| `FASTSSV_API_MCP_ALLOWED_ORIGINS` | `[]` | CSV/JSON list of `Origin` values permitted on `/mcp` from a browser. Empty = closed (any present-but-unlisted Origin → 403). |
+| `FASTSSV_API_MCP_AUTH_MODE` | `none` | Reserved for future OAuth 2.1 conformance. Today pinned to `"none"`. |
 
 A `.env` file in the working directory is loaded automatically.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ optional — the core library and CLI work without it. Install with the `api`
 extra:
 
 ```bash
-pip install "fastssv[api]"
+uv add "fastssv[api]"
 ```
 
 This pulls in `fastapi`, `uvicorn[standard]`, `gunicorn`, `slowapi`, and
@@ -18,23 +18,23 @@ This pulls in `fastapi`, `uvicorn[standard]`, `gunicorn`, `slowapi`, and
 There are two supported "one command" paths. Both launch the JSON API **and**
 the HTMX web UI from the same process (they're mounted on the same app).
 
-### `fastssv serve` — host Python
+### `uv run fastssv serve` — host Python
 
 Works for local dev, demos, and single-VM production. No Docker required.
 
 ```bash
-fastssv serve                       # dev: uvicorn, host 127.0.0.1, port 8000
-fastssv serve --reload              # + auto-reload on code changes
-fastssv serve --host 0.0.0.0 --port 9000
-fastssv serve --prod                # gunicorn + 2 uvicorn workers
-fastssv serve --prod --workers 4    # tune worker count
+uv run fastssv serve                       # dev: uvicorn, host 127.0.0.1, port 8000
+uv run fastssv serve --reload              # + auto-reload on code changes
+uv run fastssv serve --host 0.0.0.0 --port 9000
+uv run fastssv serve --prod                # gunicorn + 2 uvicorn workers
+uv run fastssv serve --prod --workers 4    # tune worker count
 ```
 
 Under the hood: dev mode invokes `uvicorn.run(...)` in-process; `--prod` execs
 `gunicorn -k uvicorn.workers.UvicornWorker ...`. Each worker loads the full
 rule registry once at startup (~154 rules, sub-second).
 
-The same process also exposes an MCP Streamable HTTP endpoint at `/mcp` when the optional `[mcp]` extra is installed (`pip install "fastssv[api,mcp]"`). See [MCP server](mcp.md) for tool surface, auth posture, and client setup.
+The same process also exposes an MCP Streamable HTTP endpoint at `/mcp` when the optional `[mcp]` extra is installed (`uv add "fastssv[api,mcp]"`). See [MCP server](mcp.md) for tool surface, auth posture, and client setup.
 
 ### `docker compose up` — containerized
 
@@ -50,7 +50,7 @@ Environment variables set in `deploy/docker-compose.yml` override the defaults
 (log level, rate limit, body-size cap, parse timeout, CORS origins, worker
 count). See the comments in that file or the Configuration section below.
 
-The container runs the same gunicorn command as `fastssv serve --prod`,
+The container runs the same gunicorn command as `uv run fastssv serve --prod`,
 uses a non-root user, mounts a read-only root filesystem, and ships a
 healthcheck against `/v1/health`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,11 @@ any SQL linter and fail any replication attempt.
 
     Run FastSSV as a FastAPI service with an HTMX web UI.
 
+-   :material-link-variant: **[MCP server](mcp.md)**
+
+    Expose FastSSV's validator over the Model Context Protocol's
+    Streamable HTTP transport.
+
 -   :material-code-json: **[JSON output](json_output.md)**
 
     The structured report format for CI integration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,9 +53,11 @@ any SQL linter and fail any replication attempt.
 
 ## Quick start
 
+From inside a uv project (`uv init` first if you don't have one):
+
 ```bash
-pip install fastssv
-fastssv path/to/query.sql
+uv add fastssv
+uv run fastssv path/to/query.sql
 ```
 
 For local development:

--- a/docs/json_output.md
+++ b/docs/json_output.md
@@ -1,13 +1,13 @@
 # JSON output format
 
-`fastssv <path>` writes a structured JSON report to disk and prints a one-line summary to the terminal. The report is the canonical machine-readable contract for CI integrations, dashboards, and any downstream tool that needs to consume validation results.
+`uv run fastssv <path>` writes a structured JSON report to disk and prints a one-line summary to the terminal. The report is the canonical machine-readable contract for CI integrations, dashboards, and any downstream tool that needs to consume validation results.
 
 ## Quick reference
 
 ```bash
-fastssv query.sql                       # writes output/validation_report.json
-fastssv query.sql --output report.json  # custom path
-fastssv query.sql --combined            # multi-statement input → single combined report
+uv run fastssv query.sql                       # writes output/validation_report.json
+uv run fastssv query.sql --output report.json  # custom path
+uv run fastssv query.sql --combined            # multi-statement input → single combined report
 ```
 
 **Exit codes**
@@ -206,7 +206,7 @@ for v in report.get("errors", []) + report.get("warnings", []):
 ### Shell + jq
 
 ```bash
-fastssv query.sql --output report.json
+uv run fastssv query.sql --output report.json
 
 # All violations across both severities
 jq '(.errors // []) + (.warnings // []) | .[] | "[\(.rule_id)] \(.issue)"' report.json

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -24,29 +24,29 @@ By default, FastSSV logs to stderr with INFO level:
 
 ```bash
 # Simple validation with default logging
-fastssv query.sql
+uv run fastssv query.sql
 ```
 
 ### Enable Debug Logging
 
 ```bash
 # CLI argument
-fastssv query.sql --log-level DEBUG
+uv run fastssv query.sql --log-level DEBUG
 
 # Or environment variable
 export FASTSSV_LOG_LEVEL=DEBUG
-fastssv query.sql
+uv run fastssv query.sql
 ```
 
 ### Log to File
 
 ```bash
 # CLI argument
-fastssv query.sql --log-file logs/validation.log
+uv run fastssv query.sql --log-file logs/validation.log
 
 # Or environment variable
 export FASTSSV_LOG_FILE=logs/validation.log
-fastssv query.sql
+uv run fastssv query.sql
 ```
 
 ---
@@ -79,7 +79,7 @@ FASTSSV_LOG_FORMAT=detailed
 Override environment variables:
 
 ```bash
-fastssv query.sql \
+uv run fastssv query.sql \
   --log-level DEBUG \
   --log-file logs/debug.log \
   --log-format json
@@ -185,16 +185,16 @@ Output:
 
 ```bash
 # Default INFO logging to console
-fastssv query.sql
+uv run fastssv query.sql
 
 # Debug logging
-fastssv query.sql --log-level DEBUG
+uv run fastssv query.sql --log-level DEBUG
 
 # Log to file
-fastssv query.sql --log-file logs/validation.log
+uv run fastssv query.sql --log-file logs/validation.log
 
 # JSON logs for production
-fastssv query.sql --log-format json --log-file logs/validation.json
+uv run fastssv query.sql --log-format json --log-file logs/validation.json
 ```
 
 ### What's Logged
@@ -226,7 +226,7 @@ The CLI logs:
 When validating multiple queries:
 
 ```bash
-fastssv queries.sql --log-level INFO
+uv run fastssv queries.sql --log-level INFO
 ```
 
 Output:
@@ -349,7 +349,7 @@ Collect logs in centralized systems:
 Example: Send JSON logs to Elasticsearch:
 
 ```bash
-fastssv query.sql --log-format json | \
+uv run fastssv query.sql --log-format json | \
   while read line; do
     curl -X POST "http://localhost:9200/fastssv-logs/_doc" \
          -H 'Content-Type: application/json' \
@@ -380,7 +380,7 @@ cat logs/fastssv.json | jq 'select(.duration_ms > 1000)'
 ### Example 1: Debug Mode with File Logging
 
 ```bash
-fastssv complex_query.sql \
+uv run fastssv complex_query.sql \
   --log-level DEBUG \
   --log-file logs/debug.log \
   --log-format detailed
@@ -393,7 +393,7 @@ export FASTSSV_LOG_LEVEL=INFO
 export FASTSSV_LOG_FORMAT=json
 export FASTSSV_LOG_FILE=logs/production.json
 
-fastssv batch_queries.sql
+uv run fastssv batch_queries.sql
 ```
 
 ### Example 3: Python API with Custom Logger

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,99 @@
+# MCP server
+
+FastSSV exposes its validator as a [Model Context Protocol](https://modelcontextprotocol.io/) server, mounted at `/mcp` on the same FastAPI app as the HTTP API. The transport is [Streamable HTTP (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http) in stateless mode (`stateless_http=True`, `json_response=True`) — no session store and no SSE resumption layer, since the rule registry is process-wide and every call is self-contained.
+
+## Install
+
+The endpoint is gated by the optional `[mcp]` extra. The Docker image bundled in `deploy/` already includes it.
+
+```sh
+pip install "fastssv[api,mcp]"
+fastssv serve  # MCP at http://localhost:8000/mcp/
+```
+
+**The MCP endpoint is opt-in.** `FASTSSV_API_MCP_ENABLED` defaults to `false` everywhere — in-code, in `deploy/docker-compose.yml`, and in `deploy/.env.example`. A deployment that doesn't think about MCP gets no MCP endpoint, by design (it's unauthenticated at the application layer; defaulting it on would be a footgun). To enable it, set `FASTSSV_API_MCP_ENABLED=true` in your env.
+
+If `FASTSSV_API_MCP_ENABLED=true` but the `mcp` extra is missing, the app logs `mcp_extra_not_installed` at startup and skips the mount.
+
+## Tool
+
+### `validate_sql(sql, dialect="auto", strict=False)`
+
+Static validation of an OMOP CDM SQL submission. Wraps [`fastssv.validate_sql_structured`](api.md) with the same statement-split, strict-mode and parse-timeout behaviour as `POST /v1/validate`. Returns a structured payload (aggregate `is_valid`/`error_count`/`warning_count`, flattened `errors` and `warnings`, and a per-statement `results` array).
+
+There is intentionally no `list_rules` tool: a static rule catalog is a poor fit for the tool primitive (the JSON-RPC `tools/list` already advertises `validate_sql`, and every violation comes back with its `rule_id`). For an enumerable catalog use the existing HTTP endpoint `GET /v1/rules` or [`docs/rules_reference.md`](rules_reference.md).
+
+## Configuration
+
+All knobs are env-driven (prefix `FASTSSV_API_`); see [`deploy/.env.example`](../deploy/.env.example) for the canonical list.
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `MCP_ENABLED` | `false` | Mount toggle (opt-in). Set to `true` to enable the endpoint. |
+| `MCP_ALLOWED_ORIGINS` | _(empty)_ | CSV or JSON list of `Origin` values permitted from a browser. Requests with no `Origin` header (curl, Claude Desktop, MCP Inspector outside a browser) always pass through; requests with a present-but-unlisted `Origin` are rejected with HTTP 403 + a JSON-RPC error body that has no `id`, per the spec's [DNS rebinding mitigation](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning). |
+| `MCP_AUTH_MODE` | `none` | Reserved knob for future OAuth 2.1 conformance. Today the Literal is pinned to `"none"`. |
+
+## Authentication and the deployment expectation
+
+[The MCP authorization spec is OPTIONAL.](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) FastSSV does not implement application-layer auth on `/mcp`. There are two reasons:
+
+1. **No per-user data.** The validator is stateless and deterministic — every caller gets identical results for identical input. Tokens scope nothing.
+2. **OAuth 2.1 is the only spec-compliant option.** The MCP spec does not allow simple shared-bearer auth; you would have to be a full OAuth 2.1 Resource Server (RFC 9728 metadata, RFC 8707 audience binding, an Authorization Server, etc.). That is significant scope for a public-domain validation utility.
+
+Operators are expected to gate `/mcp` at the reverse proxy: oauth2-proxy, Cloudflare Access, mTLS, network ACLs, or whatever their environment uses. The `behind_proxy` setting (see [`docs/api.md`](api.md)) is wired and trusts `X-Forwarded-*` headers from the upstream.
+
+## Connecting a client
+
+The endpoint is at `http://<host>/mcp/` (note the trailing slash; the spec says servers MUST provide a single endpoint that handles POST and GET).
+
+### MCP Inspector (recommended for first checks)
+
+The official [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is an npm package that gives you a browser UI for `initialize`, `tools/list`, and `tools/call`:
+
+```sh
+npx @modelcontextprotocol/inspector
+```
+
+In the UI: Transport = `Streamable HTTP`, URL = `http://localhost:8000/mcp/`, click *Connect*, then call `validate_sql` from the Tools tab.
+
+### Claude Desktop (via the `mcp-remote` stdio bridge)
+
+Claude Desktop's `claude_desktop_config.json` natively supports stdio only; the standard workaround for HTTP MCP servers is the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm package, which presents a Streamable HTTP server as a stdio process to the desktop app. Edit:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "fastssv": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:8000/mcp/"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop, then prompt: *"Use fastssv to validate this SQL: SELECT * FROM nonexistent;"*
+
+### Cursor / Claude Pro+ Custom Connectors
+
+Other MCP clients (Cursor, the Claude web app's Custom Connectors UI on Pro/Max/Team/Enterprise) accept a Streamable HTTP URL directly — point them at `https://<your-public-host>/mcp/`. Those clients typically support an `Authorization` header that you can wire to whatever your reverse proxy enforces. Note that Anthropic's Custom Connectors fetch the URL from Anthropic's servers, not the user's machine, so `localhost` is unreachable; tunnel via `cloudflared` / `ngrok` if you need to test the connector path against a local instance.
+
+## Spec conformance summary
+
+| Requirement | Status |
+| --- | --- |
+| Single endpoint supporting POST and GET | ✓ (FastMCP SDK) |
+| `Origin` validation | ✓ (`MCPOriginMiddleware`) |
+| `Accept: application/json, text/event-stream` on POST | ✓ (FastMCP SDK) |
+| `MCP-Protocol-Version` handling | ✓ (FastMCP SDK) |
+| Stateless server (no session store, no SSE resumption) | ✓ (`stateless_http=True`, `json_response=True`) |
+| Authorization (OAuth 2.1 + RFC 9728 + RFC 8707) | ✗ — OPTIONAL per spec; deferred to the reverse proxy |
+| stdio transport | ✗ — out of scope for this iteration |
+
+## References
+
+- [Streamable HTTP transport (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
+- [Authorization (2025-11-25, OPTIONAL)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [`modelcontextprotocol/python-sdk`](https://github.com/modelcontextprotocol/python-sdk)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -25,13 +25,13 @@ There is intentionally no `list_rules` tool: a static rule catalog is a poor fit
 
 ## Configuration
 
-All knobs are env-driven (prefix `FASTSSV_API_`); see [`deploy/.env.example`](../deploy/.env.example) for the canonical list.
+All knobs are env-driven; see [`deploy/.env.example`](../deploy/.env.example) for the canonical list.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `MCP_ENABLED` | `false` | Mount toggle (opt-in). Set to `true` to enable the endpoint. |
-| `MCP_ALLOWED_ORIGINS` | _(empty)_ | CSV or JSON list of `Origin` values permitted from a browser. Requests with no `Origin` header (curl, Claude Desktop, MCP Inspector outside a browser) always pass through; requests with a present-but-unlisted `Origin` are rejected with HTTP 403 + a JSON-RPC error body that has no `id`, per the spec's [DNS rebinding mitigation](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning). |
-| `MCP_AUTH_MODE` | `none` | Reserved knob for future OAuth 2.1 conformance. Today the Literal is pinned to `"none"`. |
+| `FASTSSV_API_MCP_ENABLED` | `false` | Mount toggle (opt-in). Set to `true` to enable the endpoint. |
+| `FASTSSV_API_MCP_ALLOWED_ORIGINS` | _(empty)_ | CSV or JSON list of `Origin` values permitted from a browser. Requests with no `Origin` header (curl, Claude Desktop, MCP Inspector outside a browser) always pass through; requests with a present-but-unlisted `Origin` are rejected with HTTP 403 + a JSON-RPC error body that has no `id`, per the spec's [DNS rebinding mitigation](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning). |
+| `FASTSSV_API_MCP_AUTH_MODE` | `none` | Reserved knob for future OAuth 2.1 conformance. Today the Literal is pinned to `"none"`. |
 
 ## Authentication and the deployment expectation
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,13 +7,13 @@ FastSSV exposes its validator as a [Model Context Protocol](https://modelcontext
 The endpoint is gated by the optional `[mcp]` extra. The Docker image bundled in `deploy/` already includes it.
 
 ```sh
-pip install "fastssv[api,mcp]"
-fastssv serve  # MCP at http://localhost:8000/mcp/
+uv add "fastssv[api,mcp]"
+uv run fastssv serve  # MCP at http://localhost:8000/mcp/
 ```
 
 **The MCP endpoint is opt-in.** `FASTSSV_API_MCP_ENABLED` defaults to `false` everywhere — in-code, in `deploy/docker-compose.yml`, and in `deploy/.env.example`. A deployment that doesn't think about MCP gets no MCP endpoint, by design (it's unauthenticated at the application layer; defaulting it on would be a footgun). To enable it, set `FASTSSV_API_MCP_ENABLED=true` in your env.
 
-If `FASTSSV_API_MCP_ENABLED=true` but the `mcp` extra is missing, the app logs `mcp_extra_not_installed` at startup and skips the mount.
+If `FASTSSV_API_MCP_ENABLED=true` but the `mcp` extra is missing, the app raises `RuntimeError` at startup with a clear install hint — the misconfiguration fails loudly so non-interactive deployments (CI, docker) can't silently boot without `/mcp`.
 
 ## Tool
 

--- a/docs/plugin_architecture.md
+++ b/docs/plugin_architecture.md
@@ -246,19 +246,19 @@ class TestMyNewRule:
 
 ```bash
 # Run all rules (default)
-fastssv query.sql
+uv run fastssv query.sql
 
 # Run specific category
-fastssv query.sql --categories joins
+uv run fastssv query.sql --categories joins
 
 # Run multiple categories
-fastssv query.sql --categories joins temporal
+uv run fastssv query.sql --categories joins temporal
 
 # Run specific rule
-fastssv query.sql --rules joins.my_new_rule
+uv run fastssv query.sql --rules joins.my_new_rule
 
 # Run multiple specific rules
-fastssv query.sql --rules joins.join_path_validation concept_standardization.standard_concept_enforcement
+uv run fastssv query.sql --rules joins.join_path_validation concept_standardization.standard_concept_enforcement
 ```
 
 ### Python API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ api = [
 	"slowapi>=0.1.9",
 	"pydantic-settings>=2.5",
 ]
+mcp = [
+	"mcp>=1.0",
+]
 
 [build-system]
 requires = ["uv_build>=0.9,<0.10"]

--- a/src/fastssv/api/_validation.py
+++ b/src/fastssv/api/_validation.py
@@ -1,0 +1,133 @@
+"""Shared validation runner used by both the HTTP route and the MCP tool.
+
+Keeps statement splitting, strict-mode handling, the parse timeout, and
+result aggregation in one place so the two transports can't drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import time
+from typing import List
+
+from fastapi import HTTPException, status
+
+from fastssv import validate_sql_structured
+from fastssv.api.config import Settings
+from fastssv.api.models import QueryResult, ValidationResponse, Violation
+from fastssv.core.base import Severity
+from fastssv.core.helpers import split_sql_statements
+from fastssv.core.validation_context import with_strict_mode
+
+logger = logging.getLogger("fastssv.api")
+
+
+def _sql_hash(sql: str) -> str:
+    return hashlib.sha256(sql.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _validate_each(statements, dialect):
+    out = []
+    for idx, stmt in enumerate(statements, start=1):
+        out.append((idx, stmt, validate_sql_structured(stmt, dialect=dialect)))
+    return out
+
+
+async def run_validation(
+    sql: str,
+    dialect: str,
+    strict: bool,
+    settings: Settings,
+    *,
+    client: str | None = None,
+) -> ValidationResponse:
+    """Validate a SQL submission and return the structured response.
+
+    Raises HTTPException(413) if the submission exceeds max_sql_bytes,
+    HTTPException(408) if validation exceeds parse_timeout_seconds.
+    """
+    sql_bytes = len(sql.encode("utf-8"))
+    if sql_bytes > settings.max_sql_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"SQL exceeds {settings.max_sql_bytes} byte limit.",
+        )
+
+    # A submission with no splittable content (bare keyword, comment-only
+    # input) still needs to reach the validator so the parse-error path can
+    # surface it.
+    statements = split_sql_statements(sql) or [sql]
+
+    started = time.perf_counter()
+    try:
+        with with_strict_mode(strict):
+            per_query = await asyncio.wait_for(
+                asyncio.to_thread(_validate_each, statements, dialect),
+                timeout=settings.parse_timeout_seconds,
+            )
+    except asyncio.TimeoutError as exc:
+        logger.warning(
+            "validation_timeout",
+            extra={
+                "sql_hash": _sql_hash(sql),
+                "dialect": dialect,
+                "strict": strict,
+                "query_count": len(statements),
+                "client": client,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_408_REQUEST_TIMEOUT,
+            detail=f"Validation exceeded {settings.parse_timeout_seconds}s timeout.",
+        ) from exc
+
+    duration_ms = (time.perf_counter() - started) * 1000.0
+
+    results: List[QueryResult] = []
+    all_errors: List[Violation] = []
+    all_warnings: List[Violation] = []
+    for idx, stmt, violations in per_query:
+        errs = [Violation(**v.to_dict()) for v in violations if v.severity == Severity.ERROR]
+        warns = [Violation(**v.to_dict()) for v in violations if v.severity == Severity.WARNING]
+        results.append(
+            QueryResult(
+                query_index=idx,
+                sql=stmt,
+                is_valid=len(errs) == 0,
+                error_count=len(errs),
+                warning_count=len(warns),
+                errors=errs,
+                warnings=warns,
+            )
+        )
+        all_errors.extend(errs)
+        all_warnings.extend(warns)
+
+    logger.info(
+        "validation_complete",
+        extra={
+            "sql_hash": _sql_hash(sql),
+            "dialect": dialect,
+            "strict": strict,
+            "query_count": len(statements),
+            "errors": len(all_errors),
+            "warnings": len(all_warnings),
+            "duration_ms": round(duration_ms, 2),
+            "client": client,
+        },
+    )
+
+    return ValidationResponse(
+        is_valid=len(all_errors) == 0,
+        error_count=len(all_errors),
+        warning_count=len(all_warnings),
+        errors=all_errors,
+        warnings=all_warnings,
+        query_count=len(statements),
+        results=results,
+        dialect=dialect,
+        duration_ms=round(duration_ms, 2),
+        strict=strict,
+    )

--- a/src/fastssv/api/app.py
+++ b/src/fastssv/api/app.py
@@ -199,19 +199,23 @@ def _http_error_slug(code: int) -> str:
 def _maybe_build_mcp_app(settings: Settings):
     """Build the MCP sub-app if the extra is installed and enabled.
 
-    Returns the streamable-http ASGI app or ``None``. Logs a warning when
-    the user has enabled MCP but the optional ``mcp`` package is missing.
+    Returns the streamable-http ASGI app, or ``None`` when MCP is disabled.
+    Raises ``RuntimeError`` when the user explicitly opts in via
+    ``FASTSSV_API_MCP_ENABLED=true`` but the optional ``mcp`` package is
+    missing — silently skipping the mount in non-interactive deployments
+    (CI, docker) lets misconfigured containers boot with `/mcp` absent and
+    surface the problem only when a client first tries to use it.
     """
     if not settings.mcp_enabled:
         return None
     try:
         from fastssv.mcp import build_mcp_server
-    except ImportError:
-        logger.warning(
-            "mcp_extra_not_installed",
-            extra={"hint": "install fastssv with the [mcp] extra to enable the /mcp endpoint"},
-        )
-        return None
+    except ImportError as exc:
+        raise RuntimeError(
+            "FASTSSV_API_MCP_ENABLED=true but the 'mcp' extra is not installed. "
+            "Install with `pip install 'fastssv[api,mcp]'` (or set "
+            "FASTSSV_API_MCP_ENABLED=false to disable the endpoint)."
+        ) from exc
     server = build_mcp_server(settings)
     return server.streamable_http_app()
 

--- a/src/fastssv/api/app.py
+++ b/src/fastssv/api/app.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Iterable
 
 from fastapi import FastAPI, HTTPException, Request, status
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -25,6 +26,8 @@ from fastssv.api.ui import mount_static, router as ui_router
 from fastssv.core.logging import JSONFormatter
 
 logger = logging.getLogger("fastssv.api")
+
+MCP_MOUNT_PATH = "/mcp"
 
 
 def _configure_logging(level: str) -> None:
@@ -80,11 +83,61 @@ class BodySizeLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-@asynccontextmanager
-async def _lifespan(app: FastAPI):
-    logger.info("api_startup", extra={"rules_loaded": _rules_count()})
-    yield
-    logger.info("api_shutdown")
+class MCPOriginMiddleware(BaseHTTPMiddleware):
+    """Block requests to /mcp/* whose Origin isn't allow-listed.
+
+    Per the Streamable HTTP spec's Security Warning: servers MUST validate
+    the Origin header to prevent DNS rebinding attacks. Requests with no
+    Origin header (non-browser clients like Claude Desktop, curl) are
+    allowed through; requests with a present-but-unlisted Origin are
+    rejected with 403 and a JSON-RPC error response that has no ``id``.
+    """
+
+    def __init__(self, app: ASGIApp, mount_path: str, allowed: Iterable[str]) -> None:
+        super().__init__(app)
+        self._mount_path = mount_path.rstrip("/")
+        self._allowed = {o.rstrip("/") for o in allowed}
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if not (path == self._mount_path or path.startswith(self._mount_path + "/")):
+            return await call_next(request)
+        origin = request.headers.get("origin")
+        if origin is not None and origin.rstrip("/") not in self._allowed:
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content={
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32000,
+                        "message": f"Origin '{origin}' is not allowed.",
+                    },
+                },
+            )
+        return await call_next(request)
+
+
+def _build_mcp_lifespan(mcp_apps):
+    """Compose lifespans of mounted MCP sub-apps into the parent lifecycle.
+
+    FastMCP's session manager runs as a long-lived task group that needs
+    to start before any request hits and stop cleanly on shutdown.
+    """
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI):
+        async with AsyncExitStack() as stack:
+            for sub_app in mcp_apps:
+                lifespan_cm = sub_app.router.lifespan_context(sub_app)
+                await stack.enter_async_context(lifespan_cm)
+            logger.info(
+                "api_startup",
+                extra={"rules_loaded": _rules_count(), "mcp_mounted": bool(mcp_apps)},
+            )
+            yield
+            logger.info("api_shutdown")
+
+    return _lifespan
 
 
 def _rules_count() -> int:
@@ -143,11 +196,34 @@ def _http_error_slug(code: int) -> str:
     }.get(code, "error")
 
 
+def _maybe_build_mcp_app(settings: Settings):
+    """Build the MCP sub-app if the extra is installed and enabled.
+
+    Returns the streamable-http ASGI app or ``None``. Logs a warning when
+    the user has enabled MCP but the optional ``mcp`` package is missing.
+    """
+    if not settings.mcp_enabled:
+        return None
+    try:
+        from fastssv.mcp import build_mcp_server
+    except ImportError:
+        logger.warning(
+            "mcp_extra_not_installed",
+            extra={"hint": "install fastssv with the [mcp] extra to enable the /mcp endpoint"},
+        )
+        return None
+    server = build_mcp_server(settings)
+    return server.streamable_http_app()
+
+
 def create_app(settings: Settings | None = None) -> FastAPI:
     settings = settings or get_settings()
     _configure_logging(settings.log_level)
 
     limiter = Limiter(key_func=get_remote_address, default_limits=[settings.rate_limit])
+
+    mcp_app = _maybe_build_mcp_app(settings)
+    mcp_apps = [mcp_app] if mcp_app is not None else []
 
     app = FastAPI(
         title="FastSSV API",
@@ -156,15 +232,29 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         docs_url="/docs",
         redoc_url=None,
         openapi_url="/openapi.json",
-        lifespan=_lifespan,
+        lifespan=_build_mcp_lifespan(mcp_apps),
     )
     app.state.settings = settings
     app.state.limiter = limiter
+    app.state.mcp_mounted = mcp_app is not None
 
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+    # add_middleware prepends to the stack, so the *last* registration is the
+    # outermost layer. Order matters: MCPOriginMiddleware short-circuits with
+    # a 403 when the Origin is not allow-listed, so SecurityHeadersMiddleware
+    # and RequestIDMiddleware must be *outside* it (registered after) for
+    # those headers to wrap the rejection response.
     app.add_middleware(SlowAPIMiddleware)
     app.add_middleware(BodySizeLimitMiddleware, max_bytes=settings.max_sql_bytes + 4096)
+
+    if mcp_app is not None:
+        app.add_middleware(
+            MCPOriginMiddleware,
+            mount_path=MCP_MOUNT_PATH,
+            allowed=settings.mcp_allow_origins(),
+        )
+
     app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(RequestIDMiddleware)
 
@@ -185,6 +275,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     mount_static(app)
     app.include_router(router)
     app.include_router(ui_router)
+
+    if mcp_app is not None:
+        app.mount(MCP_MOUNT_PATH, mcp_app)
 
     return app
 

--- a/src/fastssv/api/config.py
+++ b/src/fastssv/api/config.py
@@ -1,7 +1,7 @@
 """Environment-driven configuration for the FastSSV API."""
 
 import json
-from typing import Annotated, List
+from typing import Annotated, List, Literal
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -17,16 +17,31 @@ class Settings(BaseSettings):
     max_sql_bytes: int = Field(default=100_000, ge=1, le=10_000_000)
     parse_timeout_seconds: float = Field(default=5.0, gt=0, le=60)
     rate_limit: str = Field(default="60/minute")
-    # NoDecode skips pydantic-settings' built-in JSON parsing for this
-    # complex field so an empty string from the env doesn't blow up before
-    # the validator below runs.
+    # NoDecode skips pydantic-settings' built-in JSON parsing for these
+    # complex fields so an empty string from the env doesn't blow up before
+    # the validators below run.
     cors_origins: Annotated[List[str], NoDecode] = Field(default_factory=list)
     log_level: str = Field(default="INFO")
     behind_proxy: bool = Field(default=False)
 
-    @field_validator("cors_origins", mode="before")
+    # MCP (Streamable HTTP) endpoint mounted at /mcp. Opt-in everywhere:
+    # the in-code default, the compose default, and the .env.example template
+    # all default to False so a deployment that doesn't think about MCP gets
+    # no MCP endpoint. Operators flip FASTSSV_API_MCP_ENABLED=true explicitly
+    # when they want it (and have configured a reverse proxy to gate it).
+    # The `mcp` extra must also be installed for the mount to actually happen;
+    # if it's missing the app logs a warning at startup and skips the mount.
+    mcp_enabled: bool = Field(default=False)
+    mcp_allowed_origins: Annotated[List[str], NoDecode] = Field(default_factory=list)
+    # Reserved knob for future OAuth 2.1 conformance. Today only "none" is
+    # accepted; the spec permits unauthenticated MCP servers, and fastssv
+    # delegates auth to the reverse proxy. Widening the Literal is how we
+    # opt in later without churning the env-var name.
+    mcp_auth_mode: Literal["none"] = Field(default="none")
+
+    @field_validator("cors_origins", "mcp_allowed_origins", mode="before")
     @classmethod
-    def _parse_cors_origins(cls, value):
+    def _parse_origin_list(cls, value):
         # Tolerate the common env-var shapes: empty/whitespace string → [],
         # JSON list → parsed list, comma-separated string → split list.
         if value is None or value == "":
@@ -42,6 +57,9 @@ class Settings(BaseSettings):
 
     def cors_allow_origins(self) -> List[str]:
         return self.cors_origins or []
+
+    def mcp_allow_origins(self) -> List[str]:
+        return self.mcp_allowed_origins or []
 
 
 def get_settings() -> Settings:

--- a/src/fastssv/api/config.py
+++ b/src/fastssv/api/config.py
@@ -30,7 +30,10 @@ class Settings(BaseSettings):
     # no MCP endpoint. Operators flip FASTSSV_API_MCP_ENABLED=true explicitly
     # when they want it (and have configured a reverse proxy to gate it).
     # The `mcp` extra must also be installed for the mount to actually happen;
-    # if it's missing the app logs a warning at startup and skips the mount.
+    # if the operator opts in but the extra is missing,
+    # api/app.py:_maybe_build_mcp_app raises RuntimeError at startup so the
+    # misconfiguration fails loudly in CI/docker rather than silently booting
+    # without /mcp.
     mcp_enabled: bool = Field(default=False)
     mcp_allowed_origins: Annotated[List[str], NoDecode] = Field(default_factory=list)
     # Reserved knob for future OAuth 2.1 conformance. Today only "none" is

--- a/src/fastssv/api/models.py
+++ b/src/fastssv/api/models.py
@@ -87,6 +87,10 @@ class HealthResponse(BaseModel):
     status: Literal["ok"] = "ok"
     version: str
     rules_loaded: int
+    mcp_mounted: bool = Field(
+        default=False,
+        description="Whether the /mcp Streamable HTTP endpoint is currently mounted.",
+    )
 
 
 class ErrorResponse(BaseModel):

--- a/src/fastssv/api/routes.py
+++ b/src/fastssv/api/routes.py
@@ -2,39 +2,26 @@
 
 from __future__ import annotations
 
-import asyncio
-import hashlib
 import logging
-import time
 from importlib.metadata import version as pkg_version
-from typing import List
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Request
 from slowapi.util import get_remote_address
 
-from fastssv import validate_sql_structured
+from fastssv.api._validation import run_validation
 from fastssv.api.config import Settings
 from fastssv.api.models import (
     HealthResponse,
-    QueryResult,
     RuleInfo,
     RulesResponse,
     ValidationRequest,
     ValidationResponse,
-    Violation,
 )
-from fastssv.core.base import Severity
-from fastssv.core.helpers import split_sql_statements
 from fastssv.core.registry import get_all_rules
-from fastssv.core.validation_context import with_strict_mode
 
 logger = logging.getLogger("fastssv.api")
 
 router = APIRouter(prefix="/v1")
-
-
-def _sql_hash(sql: str) -> str:
-    return hashlib.sha256(sql.encode("utf-8", errors="replace")).hexdigest()[:16]
 
 
 def _category_from_rule_id(rule_id: str) -> str:
@@ -48,99 +35,13 @@ def _category_from_rule_id(rule_id: str) -> str:
 )
 async def validate(req: ValidationRequest, request: Request) -> ValidationResponse:
     settings: Settings = request.app.state.settings
-    sql_bytes = len(req.sql.encode("utf-8"))
-
-    if sql_bytes > settings.max_sql_bytes:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"SQL exceeds {settings.max_sql_bytes} byte limit.",
-        )
-
-    # Split the submission into statements so each violation can be attributed
-    # to its source query. A submission with no splittable content (e.g. a
-    # bare keyword or comment-only input) is still handed to the validator as
-    # a single statement — the existing parse-error path surfaces it cleanly.
-    statements = split_sql_statements(req.sql) or [req.sql]
-
-    started = time.perf_counter()
-    try:
-        with with_strict_mode(req.strict):
-            per_query = await asyncio.wait_for(
-                asyncio.to_thread(_validate_each, statements, req.dialect),
-                timeout=settings.parse_timeout_seconds,
-            )
-    except asyncio.TimeoutError as exc:
-        logger.warning(
-            "validation_timeout",
-            extra={
-                "sql_hash": _sql_hash(req.sql),
-                "dialect": req.dialect,
-                "strict": req.strict,
-                "query_count": len(statements),
-                "client": get_remote_address(request),
-            },
-        )
-        raise HTTPException(
-            status_code=status.HTTP_408_REQUEST_TIMEOUT,
-            detail=f"Validation exceeded {settings.parse_timeout_seconds}s timeout.",
-        ) from exc
-
-    duration_ms = (time.perf_counter() - started) * 1000.0
-
-    results: List[QueryResult] = []
-    all_errors: List[Violation] = []
-    all_warnings: List[Violation] = []
-    for idx, stmt, violations in per_query:
-        errs = [Violation(**v.to_dict()) for v in violations if v.severity == Severity.ERROR]
-        warns = [Violation(**v.to_dict()) for v in violations if v.severity == Severity.WARNING]
-        results.append(
-            QueryResult(
-                query_index=idx,
-                sql=stmt,
-                is_valid=len(errs) == 0,
-                error_count=len(errs),
-                warning_count=len(warns),
-                errors=errs,
-                warnings=warns,
-            )
-        )
-        all_errors.extend(errs)
-        all_warnings.extend(warns)
-
-    logger.info(
-        "validation_complete",
-        extra={
-            "sql_hash": _sql_hash(req.sql),
-            "dialect": req.dialect,
-            "strict": req.strict,
-            "query_count": len(statements),
-            "errors": len(all_errors),
-            "warnings": len(all_warnings),
-            "duration_ms": round(duration_ms, 2),
-            "client": get_remote_address(request),
-        },
+    return await run_validation(
+        req.sql,
+        req.dialect,
+        req.strict,
+        settings,
+        client=get_remote_address(request),
     )
-
-    return ValidationResponse(
-        is_valid=len(all_errors) == 0,
-        error_count=len(all_errors),
-        warning_count=len(all_warnings),
-        errors=all_errors,
-        warnings=all_warnings,
-        query_count=len(statements),
-        results=results,
-        dialect=req.dialect,
-        duration_ms=round(duration_ms, 2),
-        strict=req.strict,
-    )
-
-
-def _validate_each(statements, dialect):
-    """Validate each statement independently. Runs in the threadpool."""
-    out = []
-    for idx, stmt in enumerate(statements, start=1):
-        out.append((idx, stmt, validate_sql_structured(stmt, dialect=dialect)))
-    return out
 
 
 @router.get(
@@ -169,7 +70,7 @@ async def list_rules_endpoint() -> RulesResponse:
     response_model=HealthResponse,
     summary="Liveness probe",
 )
-async def health() -> HealthResponse:
+async def health(request: Request) -> HealthResponse:
     try:
         v = pkg_version("fastssv")
     except Exception:
@@ -178,4 +79,5 @@ async def health() -> HealthResponse:
         status="ok",
         version=v,
         rules_loaded=len(get_all_rules()),
+        mcp_mounted=getattr(request.app.state, "mcp_mounted", False),
     )

--- a/src/fastssv/mcp/__init__.py
+++ b/src/fastssv/mcp/__init__.py
@@ -1,0 +1,13 @@
+"""MCP (Model Context Protocol) Streamable HTTP server for FastSSV.
+
+The Streamable HTTP endpoint is mounted at ``/mcp`` by
+``fastssv.api.app.create_app`` when the optional ``[mcp]`` extra is
+installed and ``FASTSSV_API_MCP_ENABLED`` is true.
+
+See ``docs/mcp.md`` and the spec at
+https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
+"""
+
+from fastssv.mcp.server import build_mcp_server
+
+__all__ = ["build_mcp_server"]

--- a/src/fastssv/mcp/server.py
+++ b/src/fastssv/mcp/server.py
@@ -1,0 +1,84 @@
+"""FastMCP server exposing FastSSV's validator over Streamable HTTP.
+
+Stateless mode (`stateless_http=True, json_response=True`) is the spec's
+"recommended" production mode for stateless servers — there are no
+per-session resources, so we don't need session storage or SSE
+resumption. The mount path is set to "/" because the parent FastAPI app
+mounts this sub-app at "/mcp"; setting it here would double the prefix.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+
+from fastssv.api._validation import run_validation
+from fastssv.api.config import Settings
+
+logger = logging.getLogger("fastssv.mcp")
+
+
+def build_mcp_server(settings: Settings) -> FastMCP:
+    """Construct the FastMCP server with FastSSV's tool surface."""
+    # Disable the SDK's built-in DNS rebinding protection: it auto-enables a
+    # localhost-only Host allowlist when host="127.0.0.1" (FastMCP's default),
+    # which doesn't make sense for a reverse-proxied deployment where the
+    # public Host varies. The transport spec's Origin check (a separate
+    # requirement) is enforced by MCPOriginMiddleware in api/app.py against
+    # FASTSSV_API_MCP_ALLOWED_ORIGINS, and the upstream proxy is expected to
+    # validate the Host.
+    transport_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+    mcp = FastMCP(
+        name="fastssv",
+        instructions=(
+            "Static, semantic validator for SQL written against the OMOP CDM v5.4. "
+            "Use validate_sql to check a query for schema/vocabulary/modelling "
+            "errors that would otherwise pass syntax check but produce "
+            "silently-wrong analytics."
+        ),
+        stateless_http=True,
+        json_response=True,
+        transport_security=transport_security,
+    )
+    mcp.settings.streamable_http_path = "/"
+
+    @mcp.tool(
+        name="validate_sql",
+        description=(
+            "Validate an OMOP CDM SQL query. Returns per-statement and "
+            "aggregate violations (errors and warnings) without executing the "
+            "SQL — purely static analysis."
+        ),
+    )
+    async def validate_sql(
+        sql: str,
+        dialect: str = "auto",
+        strict: bool = False,
+    ) -> dict[str, Any]:
+        """Run FastSSV's full rule registry against ``sql``.
+
+        Args:
+            sql: SQL query to validate (1+ statements, ``;``-delimited).
+            dialect: ``auto`` (default), ``postgres``, ``tsql``, ``oracle``,
+                ``redshift``, ``bigquery``, ``snowflake``, ``databricks``,
+                or ``duckdb``.
+            strict: Escalate best-practice warnings to errors.
+
+        Returns:
+            Structured result: aggregate ``is_valid`` / ``error_count`` /
+            ``warning_count``, flattened ``errors`` and ``warnings``, plus
+            per-statement breakdown under ``results``.
+        """
+        try:
+            response = await run_validation(sql, dialect, strict, settings, client=None)
+        except HTTPException as exc:
+            # Surface size/timeout limits as a tool error per MCP semantics.
+            raise ValueError(exc.detail) from exc
+        return response.model_dump()
+
+    return mcp

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -33,6 +33,9 @@ def test_health_returns_ok_and_rules_count(client: TestClient):
     assert body["status"] == "ok"
     assert body["rules_loaded"] > 0
     assert "version" in body
+    # The default `client` fixture leaves MCP off; this guards against the
+    # field disappearing or flipping its default in HealthResponse.
+    assert body["mcp_mounted"] is False
 
 
 def test_validate_valid_query_returns_no_errors(client: TestClient):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -21,6 +21,9 @@ def client() -> TestClient:
         rate_limit="1000/minute",
         cors_origins=[],
         log_level="WARNING",
+        # Explicit so the test is deterministic regardless of any local
+        # `.env` that might enable MCP for dev convenience.
+        mcp_enabled=False,
     )
     app = create_app(settings)
     return TestClient(app)

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -1,0 +1,241 @@
+"""Tests for the MCP Streamable HTTP endpoint mounted at /mcp."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("mcp")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from fastssv.api.app import create_app  # noqa: E402
+from fastssv.api.config import Settings  # noqa: E402
+
+PROTOCOL_VERSION = "2025-11-25"
+ACCEPT = "application/json, text/event-stream"
+
+
+@pytest.fixture()
+def client():
+    settings = Settings(
+        max_sql_bytes=4096,
+        parse_timeout_seconds=5.0,
+        rate_limit="1000/minute",
+        cors_origins=[],
+        log_level="WARNING",
+        mcp_enabled=True,
+        mcp_allowed_origins=["https://allowed.example.com"],
+    )
+    app = create_app(settings)
+    # Use the TestClient as a context manager so the FastAPI lifespan runs;
+    # FastMCP's session manager is initialised in startup and torn down on
+    # shutdown.
+    with TestClient(app) as c:
+        yield c
+
+
+def _post(
+    client: TestClient,
+    body: Dict[str, Any],
+    *,
+    session_id: str | None = None,
+    origin: str | None = None,
+):
+    headers = {"Accept": ACCEPT, "Content-Type": "application/json"}
+    if session_id:
+        headers["MCP-Session-Id"] = session_id
+    if origin:
+        headers["Origin"] = origin
+    return client.post("/mcp/", json=body, headers=headers)
+
+
+def _parse_sse_or_json(resp) -> Dict[str, Any]:
+    ct = resp.headers.get("content-type", "")
+    if ct.startswith("application/json"):
+        return resp.json()
+    # SSE: each event line starts with "data: "; pluck the last data payload
+    payload = None
+    for line in resp.text.splitlines():
+        if line.startswith("data: "):
+            payload = json.loads(line[len("data: ") :])
+    assert payload is not None, f"no SSE data event in response: {resp.text!r}"
+    return payload
+
+
+def _initialize(client: TestClient) -> str | None:
+    """Run the MCP initialize handshake and return the session id (if any)."""
+    resp = _post(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.0.1"},
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = _parse_sse_or_json(resp)
+    assert body.get("result", {}).get("protocolVersion") == PROTOCOL_VERSION
+    sid = resp.headers.get("mcp-session-id")
+    if sid:
+        # Send the required initialized notification before any tool call.
+        ack = _post(
+            client,
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            session_id=sid,
+        )
+        assert ack.status_code in (200, 202), ack.text
+    return sid
+
+
+def test_initialize_advertises_tools_capability(client: TestClient):
+    resp = _post(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.0.1"},
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = _parse_sse_or_json(resp)
+    assert "result" in body
+    caps = body["result"]["capabilities"]
+    assert "tools" in caps
+
+
+def test_tools_list_exposes_validate_sql(client: TestClient):
+    sid = _initialize(client)
+    resp = _post(
+        client,
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        session_id=sid,
+    )
+    assert resp.status_code == 200, resp.text
+    body = _parse_sse_or_json(resp)
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert names == {"validate_sql"}
+
+
+def test_validate_sql_tool_matches_direct_validator(client: TestClient):
+    """The MCP tool result must agree with validate_sql_structured for the same input."""
+    from fastssv import validate_sql_structured
+
+    bad_sql = "SELECT * FROM nonexistent_table;"
+    sid = _initialize(client)
+    resp = _post(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "validate_sql",
+                "arguments": {"sql": bad_sql, "dialect": "postgres", "strict": False},
+            },
+        },
+        session_id=sid,
+    )
+    assert resp.status_code == 200, resp.text
+    body = _parse_sse_or_json(resp)
+    result = body["result"]
+    assert result.get("isError") is not True
+
+    # FastMCP returns structured tool output under structuredContent for tools
+    # with a return-type hint; the body is the dict our tool returned.
+    structured = result.get("structuredContent")
+    assert structured is not None, f"no structuredContent in {result!r}"
+    # Single-statement submission, so query_count is 1 and rule_ids on the
+    # MCP side match the direct call.
+    assert structured["query_count"] == 1
+    direct = validate_sql_structured(bad_sql, dialect="postgres")
+    direct_ids = sorted(v.rule_id for v in direct)
+    mcp_ids = sorted(v["rule_id"] for v in structured["errors"] + structured["warnings"])
+    assert mcp_ids == direct_ids
+
+
+def test_origin_disallowed_returns_403(client: TestClient):
+    resp = _post(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.0.1"},
+            },
+        },
+        origin="https://evil.example.com",
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    # Per the spec, the body MAY be a JSON-RPC error response with no id.
+    assert body["error"]["code"] == -32000
+    assert "id" not in body
+    # Security-headers + request-id middlewares must wrap the rejection
+    # response — regression guard against accidentally re-ordering them
+    # inside MCPOriginMiddleware. Without these, the 403 leaks audit-grade
+    # security headers and breaks request correlation.
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert resp.headers.get("x-frame-options") == "DENY"
+    assert "strict-transport-security" in resp.headers
+    assert "x-request-id" in resp.headers
+
+
+def test_origin_allowlisted_passes(client: TestClient):
+    resp = _post(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.0.1"},
+            },
+        },
+        origin="https://allowed.example.com",
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_mcp_disabled_returns_404():
+    """When mcp_enabled=False, /mcp should not be mounted."""
+    settings = Settings(
+        max_sql_bytes=1024,
+        parse_timeout_seconds=2.0,
+        rate_limit="1000/minute",
+        cors_origins=[],
+        log_level="WARNING",
+        mcp_enabled=False,
+    )
+    app = create_app(settings)
+    with TestClient(app) as c:
+        resp = c.get("/mcp/")
+        assert resp.status_code == 404
+        # /v1/health should reflect the disabled state too.
+        health = c.get("/v1/health").json()
+        assert health["mcp_mounted"] is False
+
+
+def test_health_reflects_mcp_mounted(client: TestClient):
+    """When the /mcp mount succeeded, /v1/health reports mcp_mounted=true."""
+    resp = client.get("/v1/health")
+    assert resp.status_code == 200
+    assert resp.json()["mcp_mounted"] is True

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -239,3 +239,30 @@ def test_health_reflects_mcp_mounted(client: TestClient):
     resp = client.get("/v1/health")
     assert resp.status_code == 200
     assert resp.json()["mcp_mounted"] is True
+
+
+def test_mcp_enabled_but_extra_missing_raises(monkeypatch):
+    """Fail loudly at startup when MCP_ENABLED=true but the [mcp] extra is missing.
+
+    Silent skip in non-interactive deployments (CI, docker) would let
+    misconfigured containers boot with /mcp absent and surface the problem
+    only when a client first tries to use it. The startup-time RuntimeError
+    forces the operator to either install the extra or flip MCP_ENABLED off.
+    """
+    import sys
+
+    # Force the `from fastssv.mcp import build_mcp_server` line in
+    # _maybe_build_mcp_app to raise ImportError, simulating a deploy that
+    # set FASTSSV_API_MCP_ENABLED=true without installing the [mcp] extra.
+    monkeypatch.setitem(sys.modules, "fastssv.mcp", None)
+
+    settings = Settings(
+        max_sql_bytes=1024,
+        parse_timeout_seconds=2.0,
+        rate_limit="1000/minute",
+        cors_origins=[],
+        log_level="WARNING",
+        mcp_enabled=True,
+    )
+    with pytest.raises(RuntimeError, match="MCP_ENABLED=true but the 'mcp' extra is not installed"):
+        create_app(settings)

--- a/tests/api/test_ui.py
+++ b/tests/api/test_ui.py
@@ -21,6 +21,10 @@ def client() -> TestClient:
         rate_limit="1000/minute",
         cors_origins=[],
         log_level="WARNING",
+        # Explicit so the UI tests don't pull in the FastMCP session manager
+        # via a local `.env` that happens to enable MCP — that lifespan is
+        # tested separately in tests/api/test_mcp.py.
+        mcp_enabled=False,
     )
     app = create_app(settings)
     return TestClient(app)

--- a/uv.lock
+++ b/uv.lock
@@ -41,12 +41,103 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -186,6 +277,66 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -430,7 +581,7 @@ wheels = [
 
 [[package]]
 name = "fastssv"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "sqlglot" },
@@ -451,11 +602,15 @@ docs = [
     { name = "pymdown-extensions" },
     { name = "zensical" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.115" },
     { name = "gunicorn", marker = "extra == 'api'", specifier = ">=22.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "pydantic-settings", marker = "extra == 'api'", specifier = ">=2.5" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -464,7 +619,7 @@ requires-dist = [
     { name = "sqlglot", specifier = ">=24.6.0" },
     { name = "zensical", marker = "extra == 'docs'", specifier = ">=0.0.39" },
 ]
-provides-extras = ["dev", "docs", "api"]
+provides-extras = ["dev", "docs", "api", "mcp"]
 
 [[package]]
 name = "gunicorn"
@@ -559,6 +714,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -586,6 +750,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -709,6 +900,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -733,6 +949,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -910,6 +1135,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pymdown-extensions"
 version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -970,6 +1212,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1034,6 +1298,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1185,6 +1463,128 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.58.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1225,6 +1625,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/b6/f188b9616bef49943353f3622d726af30fdb08acbd081deef28ba43ceb48/sqlglot-28.6.0.tar.gz", hash = "sha256:8c0a432a6745c6c7965bbe99a17667c5a3ca1d524a54b31997cf5422b1727f6a", size = 5676522, upload-time = "2026-01-13T17:39:24.389Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/a6/21b1e19994296ba4a34bc7abaf4fcb40d7e7787477bdfde58cd843594459/sqlglot-28.6.0-py3-none-any.whl", hash = "sha256:8af76e825dc8456a49f8ce049d69bbfcd116655dda3e53051754789e2edf8eba", size = 575186, upload-time = "2026-01-13T17:39:22.327Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/82/10cdfab4ab663a6b6bd624d33f55b2cfa41af5105be033a6d5d135a92c5f/sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489", size = 35236, upload-time = "2026-05-06T19:42:13.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/27/351c71e803c56090d8d3bf9520422debeb8ed938871fd4f7ef519805a6c5/sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f", size = 16516, upload-time = "2026-05-06T19:42:12.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Mount an MCP Streamable HTTP server at `/mcp` alongside the existing FastAPI app, behind a new `[mcp]` optional extra. Single tool: `validate_sql` (wraps `validate_sql_structured` with the same statement-split, strict mode, and timeout semantics as `POST /v1/validate`).
- **Opt-in by default.** `FASTSSV_API_MCP_ENABLED=false` everywhere (in-code, compose, `.env.example`); operators flip it to `true` only after gating `/mcp` at their reverse proxy.
- **No app-layer auth.**  Since [The MCP authorization spec is OPTIONAL](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) and MCP spec forbids simple bearer token, plus the fact that FastSSV is a stateless validator has no per-user resources to gate. However, exposing the server directly to the internet is dangerous, so a reverse proxy (oauth2-proxy, mTLS, Cloudflare Access, network ACLs) before exposing publicly is recommended. Documented in `docs/mcp.md`.
- Browsers can be tricked by malicious websites into making requests to local servers — a class of attacks called DNS rebinding. The MCP spec requires servers to defend against this by checking the Origin header (the browser-attached "this request came from page X" header) on every request. We added a small middleware that does this check before any MCP logic runs: (1) Browser requests carry an Origin header. If the value isn't in the configured allowlist, the middleware returns 403 Forbidden and the request never reaches the MCP code. The allowlist is the new env var FASTSSV_API_MCP_ALLOWED_ORIGINS (comma-separated or JSON list of origins, e.g. https://chat.example.com). (2) Non-browser clients — curl, Claude Desktop, MCP Inspector, our test suite — don't send an Origin header (they aren't subject to DNS rebinding) and pass through unconditionally. (3) The default is closed. An empty allowlist (the default) means no browser-originated request is accepted; only non-browser callers can reach /mcp. The 403 response is shaped as a JSON-RPC error so MCP clients can parse it cleanly. See MCP Streamable HTTP Security Warning for the spec language.
- Migration to uv native for final users too