### PR TITLE
Refactor rules to remove some false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,33 @@ between minor versions.
 
 ### Added
 
-- **New rule `anti_patterns.cte_shadows_omop_table`.** Warns when a CTE's
-  alias collides with an OMOP CDM table name (`cohort`, `concept`,
-  `person`, `condition_occurrence`, `concept_relationship`, …). Naming a
-  CTE after an OMOP table is legal SQL but a real code smell: every
-  unqualified reference inside the query binds to the CTE rather than
-  the OMOP table, which (a) makes the query harder to read, (b) breaks
-  any later edit that adds a real OMOP reference, and (c) makes
-  suggested fixes from other rules unusable when applied verbatim
-  (e.g. `JOIN concept c ON …` would bind to a `concept` CTE that has
-  no `standard_concept` column). Severity: `WARNING`. The suggested
-  fix is to rename the CTE; schema-qualifying every OMOP reference is
-  offered as a fallback. Powered by the existing
-  `fastssv.schemas.CDM_COLUMN_TYPES` table set — adding a new OMOP
-  table to that source of truth automatically extends this rule's
-  coverage. Tests: `tests/test_rules.py::TestCteShadowsOmopTable`
-  (6 cases including multi-shadow and case-insensitive matching).
+- **New rule `anti_patterns.cte_shadows_omop_table`.** Warns when a CTE
+  alias **or a derived-table subquery alias** collides with an OMOP CDM
+  table name (`cohort`, `concept`, `person`, `condition_occurrence`,
+  `concept_relationship`, …). Naming a CTE or `FROM (SELECT …) AS x`
+  subquery after an OMOP table is legal SQL but a real code smell: every
+  unqualified reference inside the query block binds to the local
+  construct rather than the OMOP table, which (a) makes the query harder
+  to read, (b) breaks any later edit that adds a real OMOP reference,
+  and (c) **for the CTE case specifically**, makes suggested fixes from
+  other rules unusable when applied verbatim (e.g. `JOIN concept c ON …`
+  would bind to a `concept` CTE that has no `standard_concept` column).
+  Harm (c) does NOT apply to derived-table subqueries because their
+  aliases are scope-local — sibling FROM items don't see them — so the
+  warning message for the subquery case is tuned to focus on
+  readability/edit-hazard only. Severity: `WARNING` for both kinds.
+  Anonymous subqueries (`WHERE x IN (SELECT …)`) and scalar subqueries
+  in the SELECT list (`SELECT (SELECT …) AS concept FROM t`) are
+  intentionally skipped — they don't introduce a range variable that a
+  reader has to disambiguate. The suggested fix is to rename the CTE or
+  alias; schema-qualifying every OMOP reference is offered as a
+  fallback. Powered by the existing `fastssv.schemas.CDM_COLUMN_TYPES`
+  table set — adding a new OMOP table to that source of truth
+  automatically extends this rule's coverage. Violations expose
+  `details["alias_kind"] in {"cte", "subquery"}` for downstream
+  filtering. Tests: `tests/test_rules.py::TestCteShadowsOmopTable`
+  (12 cases covering both CTE and subquery shapes, scalar-subquery and
+  anonymous-subquery exclusions, and case-insensitive matching).
 
 - **MCP (Model Context Protocol) Streamable HTTP endpoint at `/mcp`.** A
   new optional `[mcp]` extra (`uv add fastssv[mcp]`) brings in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ between minor versions.
 
 ### Added
 
+- **New rule `anti_patterns.cte_shadows_omop_table`.** Warns when a CTE's
+  alias collides with an OMOP CDM table name (`cohort`, `concept`,
+  `person`, `condition_occurrence`, `concept_relationship`, …). Naming a
+  CTE after an OMOP table is legal SQL but a real code smell: every
+  unqualified reference inside the query binds to the CTE rather than
+  the OMOP table, which (a) makes the query harder to read, (b) breaks
+  any later edit that adds a real OMOP reference, and (c) makes
+  suggested fixes from other rules unusable when applied verbatim
+  (e.g. `JOIN concept c ON …` would bind to a `concept` CTE that has
+  no `standard_concept` column). Severity: `WARNING`. The suggested
+  fix is to rename the CTE; schema-qualifying every OMOP reference is
+  offered as a fallback. Powered by the existing
+  `fastssv.schemas.CDM_COLUMN_TYPES` table set — adding a new OMOP
+  table to that source of truth automatically extends this rule's
+  coverage. Tests: `tests/test_rules.py::TestCteShadowsOmopTable`
+  (6 cases including multi-shadow and case-insensitive matching).
+
 - **MCP (Model Context Protocol) Streamable HTTP endpoint at `/mcp`.** A
   new optional `[mcp]` extra (`uv add fastssv[mcp]`) brings in the
   official `mcp` Python SDK and mounts a stateless Streamable HTTP server
@@ -48,6 +65,18 @@ between minor versions.
   normally — `[api]`-only installs still work.
 
 ### Changed
+
+- **`concept_standardization.standard_concept_enforcement`'s suggested
+  fix is now CTE-shadow-aware.** When the rule fires AND a CTE named
+  `concept` or `concept_relationship` is in scope, the message now
+  recommends the schema-qualified `JOIN omop.concept c ON …` form and
+  explicitly calls out the shadow (the old hardcoded
+  `JOIN concept c ON …` would bind to the CTE and fail at execution
+  with _"column standard_concept does not exist"_, making the fix
+  un-applyable). The default message — used when no shadow is in
+  scope — is unchanged. Regression tests:
+  `TestStandardConceptMapping::test_suggested_fix_is_schema_qualified_under_cte_shadow`
+  and `…test_suggested_fix_unchanged_without_cte_shadow`.
 
 - **`parse_sql` is now `lru_cache`-d on `(sql, dialect)`.** A single
   `validate_sql_structured` call dispatches to ~150 registered rules,
@@ -278,6 +307,124 @@ between minor versions.
   example that referenced a nonexistent `validate_anti_patterns` symbol.
 
 ### Fixed
+
+- **`data_quality.schema_validation` is now scope-aware for column
+  resolution.** `comprehensive_schema_validation` previously resolved
+  every `Column` ref through the global `extract_aliases` dict, which
+  is a flat name -> table map. When the same alias was used across
+  CTEs (for example `omop.concept c` inside one CTE and `cond_occ c` in
+  the outer SELECT), the dict collapsed to last-write-wins and the
+  rule misattributed columns — yielding spurious errors like
+  _"Column 'person_id' does not exist in table 'concept'"_ on
+  perfectly valid SQL. The rule now walks each `Column`'s enclosing
+  `Select` scope to build a scope-local alias map (correlated outer
+  scopes are still visible; inner scopes shadow). On a representative
+  11k-query benchmark this drops `schema_validation` errors from 341
+  to 131. The new helpers (`_local_aliases`, `_resolve_column_table`)
+  are private to the rule, since the global `extract_aliases` is still
+  the right contract for rules that work on join-condition pairs.
+  Regression test:
+  `tests/test_rules.py::TestSchemaValidation::test_alias_collision_across_ctes_does_not_false_positive`.
+
+- **`data_quality.schema_validation` no longer flags `DATEDIFF` unit
+  keywords as missing columns.** sqlglot parses `DATEDIFF(day, x, y)`
+  with `day` as a `Column` node (rather than a literal/Var). Without
+  filtering, the schema check produced
+  _"Column 'day' does not exist in table 'condition_occurrence'"_ for
+  every query that used `DATEDIFF`/`DATEADD`/`DATETRUNC`/`EXTRACT` etc.
+  The rule now skips unqualified `Column` nodes whose name is a
+  recognised time-unit keyword (`day`, `month`, `year`, `hour`,
+  `minute`, …) and whose parent is one of the date-arithmetic
+  function types. Regression test:
+  `tests/test_rules.py::TestSchemaValidation::test_datediff_unit_keyword_not_treated_as_column`.
+
+- **`joins.visit_occurrence_inner_join_validation` no longer warns on
+  non-VOID join keys.** OMOP_043's premise is that an `INNER JOIN
+  visit_occurrence ON event.visit_occurrence_id = vo.visit_occurrence_id`
+  silently drops the 20–60% of clinical events with NULL
+  `visit_occurrence_id`. That premise only applies when the JOIN key is
+  actually `visit_occurrence_id` — but `_is_vo_join` previously fired
+  on any INNER JOIN that *involved* `visit_occurrence`, regardless of
+  key. The canonical cohort-builder shape
+  `cohort c JOIN visit_occurrence vo ON c.person_id = vo.person_id`
+  (where `person_id` is NOT NULL on both sides and no rows can be
+  dropped due to NULL visit linkage) was therefore flagged as a
+  potentially-data-losing INNER JOIN. The rule now gates on a new
+  `_join_on_uses_visit_occurrence_id` check that walks the ON clause
+  for a `visit_occurrence_id` column reference; mixed-key joins
+  (`ON co.visit_occurrence_id = vo.visit_occurrence_id AND co.person_id = vo.person_id`)
+  still fire because VOID linkage is in play. The implicit/comma-join
+  branch is unchanged — comma-joining `visit_occurrence` to an event
+  table almost always means visit linkage and is left as a warning.
+  Regression tests:
+  `tests/test_rules.py::TestVisitOccurrenceInnerJoinValidation::test_omop_043_person_id_join_to_visit_does_not_fire`
+  and `…test_omop_043_mixed_keys_still_fires`.
+
+- **`anti_patterns.limit_without_order_by` no longer warns on scalar
+  aggregations.** A `SELECT COUNT(DISTINCT person_id) … LIMIT 1000` —
+  the textbook Atlas/OHDSI patient-count shape — returns exactly one
+  row, so `LIMIT N` is a no-op and the missing-`ORDER BY` warning is a
+  false positive (4/5 FPs of this shape in audit sampling). The rule
+  now skips a `Select` when (a) it has no `GROUP BY` / `HAVING`, (b) at
+  least one projection contains an aggregate, and (c) no projection has
+  a bare (non-aggregated) `Column` reference. Star projections,
+  bare-column projections, and `GROUP BY`-driven multi-row results
+  continue to warn as before. Regression tests:
+  `tests/test_rules.py::TestLimitWithoutOrderBy`.
+
+- **`joins.join_path_validation` now recognises IN-subquery CTE
+  bridges.** The pre-existing CTE-bridge check only inspected `JOIN ON`
+  equalities, missing the canonical concept-set shape
+  `WHERE x_concept_id IN (SELECT concept_id FROM <vocab_cte>)` — every
+  Atlas-style cohort builder that materialises drug/condition concept
+  sets in a CTE and feeds them into `drug_exposure`/`condition_occurrence`
+  via `IN`-subquery was hit with a spurious _"Query uses 'concept' table
+  but it may not be properly joined…"_ warning (5/5 FPs of this shape
+  in audit sampling). A new private helper
+  `_has_in_subquery_bridge_to_vocab_cte` walks `exp.In` nodes whose LHS
+  is a `_concept_id` column and whose RHS subquery (`In.args["query"]`)
+  selects from a vocab CTE, treating that as a valid indirect bridge.
+  Additive — JOIN-on, comma-join WHERE, and direct-JOIN paths all
+  remain. Regression test:
+  `tests/test_rules.py::TestJoinPathValidation::test_in_subquery_bridge_to_vocab_cte_does_not_fire`.
+
+- **`joins.left_join_then_where_on_right_table` is now scope-aware.**
+  The rule previously built a tree-wide pool of "right tables that appear
+  on the right of any `LEFT JOIN`" and matched it against every `WHERE`
+  in the tree, so a `LEFT JOIN omop.concept_relationship cr` declared in
+  one CTE got cross-linked with a `WHERE cr.relationship_id = 'Maps to'`
+  living in a *different* sibling CTE that re-used the alias `cr` for an
+  ordinary `INNER JOIN` — producing spurious _"LEFT JOIN followed by
+  WHERE filtering right table column(s): concept_relationship.relationship_id"_
+  reports on standard Maps-to vocabulary plumbing. The check is now done
+  per `Select` scope: each scope's LEFT-JOIN right-tables are matched
+  only against that scope's own `WHERE`, with column resolution going
+  through a scope-local alias map (mirroring the `comprehensive_schema_validation`
+  pattern from the previous fix). True positives within a single scope
+  still fire as before. Regression tests:
+  `tests/test_rules.py::TestLeftJoinThenWhereOnRightTable::test_omop_149_alias_collision_across_ctes_does_not_false_positive`
+  and `…test_omop_149_left_join_in_inner_cte_still_fires_in_own_scope`.
+
+- **OMOP-table-targeting rules no longer false-positive on user CTEs that
+  shadow OMOP table names.** `core.helpers.has_table_reference` is the
+  gating check used by ~50 rules that key off specific OMOP tables
+  (`cohort`, `person`, `concept`, the join family, etc.) — and it
+  previously treated `WITH cohort AS (...) ... FROM cohort c` as a
+  reference to the OMOP `cohort` table, so a CTE named `cohort` with
+  its own `person_id` column would trip
+  `joins.cohort_clinical_join_validation` (and the like) with messages
+  like _"Invalid FK join between cohort and condition_occurrence:
+  cohort.person_id = …"_ even though the SQL was perfectly valid. The
+  helper is now CTE-aware: an unqualified reference whose name matches
+  a CTE defined in scope is treated as the CTE; schema-qualified
+  references (`mydb.cohort`) bypass the shadow per standard SQL
+  scoping. A new `collect_cte_names(tree)` helper is exported for
+  rules that want to apply the same guard at column-resolution time.
+  `extract_aliases` is intentionally unchanged — `joins.join_path_validation`
+  and other rules with their own CTE-bridge logic depend on its current
+  bare-name semantics. Regression tests added in
+  `tests/test_helpers_cte.py` and
+  `tests/test_rules.py::TestCohortClinicalJoinValidation`.
 
 - **`deploy/.env.example` documents `FASTSSV_API_BEHIND_PROXY`.** The
   reverse-proxy toggle added with HTTPS support is wired through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,15 +79,25 @@ between minor versions.
 
 - **`concept_standardization.standard_concept_enforcement`'s suggested
   fix is now CTE-shadow-aware.** When the rule fires AND a CTE named
-  `concept` or `concept_relationship` is in scope, the message now
-  recommends the schema-qualified `JOIN omop.concept c ON …` form and
-  explicitly calls out the shadow (the old hardcoded
-  `JOIN concept c ON …` would bind to the CTE and fail at execution
-  with _"column standard_concept does not exist"_, making the fix
-  un-applyable). The default message — used when no shadow is in
-  scope — is unchanged. Regression tests:
-  `TestStandardConceptMapping::test_suggested_fix_is_schema_qualified_under_cte_shadow`
-  and `…test_suggested_fix_unchanged_without_cte_shadow`.
+  `concept` or `concept_relationship` is defined **at the top level of
+  the statement**, the message now recommends the schema-qualified
+  `JOIN omop.concept c ON …` form and explicitly calls out the shadow
+  (the old hardcoded `JOIN concept c ON …` would bind to the CTE and
+  fail at execution with _"column standard_concept does not exist"_,
+  making the fix un-applyable). Scope is deliberately restricted to the
+  top-level WITH (`tree.args["with_"]`) rather than tree-global: CTEs
+  defined inside a nested subquery (IN / EXISTS / FROM-derived) are
+  lexically out of scope for a JOIN added at the outer SELECT, so the
+  generic fix is already executable in that case and emitting the
+  shadow-note would be misleading. The broader "any matching CTE
+  anywhere in the tree" signal is handled separately by
+  `anti_patterns.cte_shadows_omop_table`. The default message — used
+  when no top-level shadow is present — is unchanged. Regression tests:
+  `TestStandardConceptMapping::test_suggested_fix_is_schema_qualified_under_cte_shadow`,
+  `…test_suggested_fix_unchanged_without_cte_shadow`, and
+  `…test_suggested_fix_unchanged_when_concept_cte_is_nested_subquery`
+  (the new case, added in response to a Copilot review flag that the
+  earlier tree-global `collect_cte_names` over-approximated scope).
 
 - **`parse_sql` is now `lru_cache`-d on `(sql, dialect)`.** A single
   `validate_sql_structured` call dispatches to ~150 registered rules,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,27 +350,42 @@ between minor versions.
   (where `person_id` is NOT NULL on both sides and no rows can be
   dropped due to NULL visit linkage) was therefore flagged as a
   potentially-data-losing INNER JOIN. The rule now gates on a new
-  `_join_on_uses_visit_occurrence_id` check that walks the ON clause
-  for a `visit_occurrence_id` column reference; mixed-key joins
+  `_join_on_uses_visit_occurrence_id` check that walks `exp.EQ` nodes
+  in the ON clause and only returns True when `visit_occurrence_id`
+  appears on at least one side of an *equality* (not just anywhere in
+  the ON clause — an earlier draft walked every `exp.Column` and
+  reintroduced the same false positive class via non-equality
+  predicates like `vo.visit_occurrence_id IS NOT NULL` or
+  `vo.visit_occurrence_id > 0`; caught in code review). Mixed-key joins
   (`ON co.visit_occurrence_id = vo.visit_occurrence_id AND co.person_id = vo.person_id`)
   still fire because VOID linkage is in play. The implicit/comma-join
   branch is unchanged — comma-joining `visit_occurrence` to an event
   table almost always means visit linkage and is left as a warning.
   Regression tests:
-  `tests/test_rules.py::TestVisitOccurrenceInnerJoinValidation::test_omop_043_person_id_join_to_visit_does_not_fire`
-  and `…test_omop_043_mixed_keys_still_fires`.
+  `tests/test_rules.py::TestVisitOccurrenceInnerJoinValidation::test_omop_043_person_id_join_to_visit_does_not_fire`,
+  `…test_omop_043_mixed_keys_still_fires`,
+  `…test_omop_043_void_in_non_equality_predicate_does_not_fire`,
+  `…test_omop_043_void_comparison_predicate_does_not_fire`,
+  and `…test_omop_043_void_equality_to_literal_still_fires`.
 
 - **`anti_patterns.limit_without_order_by` no longer warns on scalar
   aggregations.** A `SELECT COUNT(DISTINCT person_id) … LIMIT 1000` —
   the textbook Atlas/OHDSI patient-count shape — returns exactly one
   row, so `LIMIT N` is a no-op and the missing-`ORDER BY` warning is a
   false positive (4/5 FPs of this shape in audit sampling). The rule
-  now skips a `Select` when (a) it has no `GROUP BY` / `HAVING`, (b) at
-  least one projection contains an aggregate, and (c) no projection has
-  a bare (non-aggregated) `Column` reference. Star projections,
-  bare-column projections, and `GROUP BY`-driven multi-row results
-  continue to warn as before. Regression tests:
-  `tests/test_rules.py::TestLimitWithoutOrderBy`.
+  now skips a `Select` when (a) it has no `GROUP BY` / `HAVING`, (b) no
+  projection contains a window function (`f(...) OVER (...)`; windowed
+  aggregates are per-row, not row-collapsing), (c) at least one
+  projection contains a non-windowed aggregate, and (d) no projection
+  has a bare (non-aggregated) `Column` reference. Star projections,
+  bare-column projections, window functions, and `GROUP BY`-driven
+  multi-row results continue to warn as before. Regression tests:
+  `tests/test_rules.py::TestLimitWithoutOrderBy` (10 cases including
+  three windowed-aggregate shapes — `SUM(x) OVER ()`,
+  `ROW_NUMBER() OVER (ORDER BY …)`, and
+  `COUNT(*) OVER (PARTITION BY …)` — added after code review caught
+  an earlier draft that treated the inner `AggFunc` inside an
+  `exp.Window` as scalar-agg evidence).
 
 - **`joins.join_path_validation` now recognises IN-subquery CTE
   bridges.** The pre-existing CTE-bridge check only inspected `JOIN ON`
@@ -415,15 +430,27 @@ between minor versions.
   `joins.cohort_clinical_join_validation` (and the like) with messages
   like _"Invalid FK join between cohort and condition_occurrence:
   cohort.person_id = …"_ even though the SQL was perfectly valid. The
-  helper is now CTE-aware: an unqualified reference whose name matches
-  a CTE defined in scope is treated as the CTE; schema-qualified
-  references (`mydb.cohort`) bypass the shadow per standard SQL
-  scoping. A new `collect_cte_names(tree)` helper is exported for
-  rules that want to apply the same guard at column-resolution time.
-  `extract_aliases` is intentionally unchanged — `joins.join_path_validation`
-  and other rules with their own CTE-bridge logic depend on its current
-  bare-name semantics. Regression tests added in
-  `tests/test_helpers_cte.py` and
+  helper is now CTE-aware *per Table node*: for each unqualified
+  reference, the helper walks the reference's ancestor `Select` scopes
+  and checks each one's WITH clause; if a CTE with the matching name
+  is visible from that scope (and the reference isn't inside the CTE's
+  own body — non-recursive self-reference rule), the reference is
+  treated as the CTE. Schema-qualified references (`mydb.cohort`)
+  always bypass shadowing per standard SQL scoping. The per-node
+  walk avoids over-approximating CTE visibility: a CTE named `cohort`
+  defined inside a nested subquery does NOT shadow an outer
+  `FROM cohort` (an earlier draft of this fix used a tree-global
+  `collect_cte_names` intersection and would have silently suppressed
+  in that case — caught in code review). A new `collect_cte_names(tree)`
+  helper is also exported for callers that *do* want the tree-global
+  set (e.g. `anti_patterns.cte_shadows_omop_table`, which flags any
+  shadow no matter how nested) — its docstring is explicit about the
+  over-approximation. `extract_aliases` is intentionally unchanged —
+  `joins.join_path_validation` and other rules with their own
+  CTE-bridge logic depend on its current bare-name semantics.
+  Regression tests added in `tests/test_helpers_cte.py` (covering
+  outer-WITH shadow, schema-qualified bypass, nested-WITH non-shadow,
+  and self-reference resolution) and
   `tests/test_rules.py::TestCohortClinicalJoinValidation`.
 
 - **`deploy/.env.example` documents `FASTSSV_API_BEHIND_PROXY`.** The

--- a/src/fastssv/api/static/style.css
+++ b/src/fastssv/api/static/style.css
@@ -1445,6 +1445,51 @@ button[type="submit"]:disabled { opacity: 0.6; cursor: progress; }
   gap: 0.1rem;
   flex: none;
 }
+
+/* MCP server status pill. Lives in .panel-toolbar (same row as the
+   dialect select and the "Try: …" example chips), pushed to the right
+   edge via margin-left:auto so it sits in the top-right corner above
+   the editor without competing with the title/icon buttons inside
+   the editor-bar. Uses --ok-* tokens for the on state and --muted for
+   off so the pill colors stay in sync with light/dark theme switches. */
+.mcp-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+  /* Slightly smaller than .chip — the pill is informational (read-only),
+     not interactive, so it should sit unobtrusively in the toolbar. The
+     explicit line-height:1 keeps the box tight even though font-size
+     matches roughly. */
+  padding: 0.3rem 0.65rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  user-select: none;
+  cursor: default;
+}
+.mcp-pill-dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 0 currentColor;
+}
+.mcp-pill-on {
+  color: var(--ok-fg);
+  background: var(--ok-bg);
+  border-color: color-mix(in srgb, var(--ok-fg) 25%, transparent);
+}
+.mcp-pill-off {
+  color: var(--muted);
+  background: var(--code-bg);
+  border-color: var(--border);
+}
 .editor-title {
   margin: 0;
   font-size: 0.88rem;

--- a/src/fastssv/api/templates/index.html
+++ b/src/fastssv/api/templates/index.html
@@ -57,6 +57,14 @@
     <button type="button" class="chip" data-action="example" data-example="unknown_table">Unknown table</button>
     <button type="button" class="chip" data-action="example" data-example="multi_statement">Multiple statements</button>
   </div>
+
+  <span class="mcp-pill {% if mcp_enabled %}mcp-pill-on{% else %}mcp-pill-off{% endif %}"
+        role="status"
+        aria-label="MCP server is {{ 'enabled' if mcp_enabled else 'disabled' }}"
+        title="{% if mcp_enabled %}Model Context Protocol server is enabled and serving at {{ mcp_mount_path }}{% else %}Model Context Protocol server is disabled (set FASTSSV_API_MCP_ENABLED=true and install the [mcp] extra to enable){% endif %}">
+    <span class="mcp-pill-dot" aria-hidden="true"></span>
+    <span class="mcp-pill-label">MCP&nbsp;·&nbsp;{{ 'on' if mcp_enabled else 'off' }}</span>
+  </span>
 </div>
 
 <form id="validate-form" class="editor-form"

--- a/src/fastssv/api/ui.py
+++ b/src/fastssv/api/ui.py
@@ -108,6 +108,10 @@ router = APIRouter(tags=["ui"])
 @router.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def index(request: Request):
     settings: Settings = request.app.state.settings
+    # `mcp_mounted` is the *truthful* signal — settings.mcp_enabled can be
+    # True at config time, but the sub-app only mounts when the optional
+    # `mcp` extra is also importable. Use the live-mount state for the pill.
+    mcp_enabled = bool(getattr(request.app.state, "mcp_mounted", False))
     return templates.TemplateResponse(
         request,
         "index.html",
@@ -115,6 +119,8 @@ async def index(request: Request):
             "active": "validate",
             "rules_loaded": _rules_loaded(),
             "max_sql_bytes": settings.max_sql_bytes,
+            "mcp_enabled": mcp_enabled,
+            "mcp_mount_path": "/mcp" if mcp_enabled else None,
         },
     )
 

--- a/src/fastssv/core/helpers.py
+++ b/src/fastssv/core/helpers.py
@@ -322,8 +322,15 @@ def parse_sql(sql: str, dialect: str = "postgres") -> Tuple[Optional[List[exp.Ex
 def collect_cte_names(tree: exp.Expression) -> Set[str]:
     """Return the set of CTE names defined in any WITH clause within ``tree``.
 
-    Used by OMOP-table-targeting rules to distinguish between an actual OMOP
-    table reference and an unqualified reference to a same-named user CTE.
+    NOTE: this is a *tree-global* aggregation — it picks up CTEs defined in
+    nested subqueries as well as the top-level WITH. That's appropriate for
+    callers that want to surface the shadow itself (e.g.
+    ``anti_patterns.cte_shadows_omop_table`` flags any matching CTE no
+    matter how nested), but it over-approximates standard SQL lexical
+    scoping: a nested CTE named ``cohort`` is *not* visible to an outer
+    ``FROM cohort``. Callers that need a per-table-node shadow check
+    should not use this set — see ``has_table_reference`` (which now
+    walks ancestor WITH clauses per Table node instead).
     """
     return {normalize_name(cte.alias) for cte in tree.find_all(exp.CTE) if cte.alias}
 
@@ -334,6 +341,52 @@ def _is_schema_qualified(t: exp.Table) -> bool:
     per standard SQL scoping rules.
     """
     return bool(t.args.get("db") or t.args.get("catalog"))
+
+
+def _is_descendant_of(node: exp.Expression, root: Optional[exp.Expression]) -> bool:
+    """True if ``node`` is ``root`` or anywhere in the subtree rooted at it."""
+    if root is None:
+        return False
+    cursor = node
+    while cursor is not None:
+        if cursor is root:
+            return True
+        cursor = cursor.parent
+    return False
+
+
+def _is_shadowed_by_visible_cte(table_node: exp.Table, target: str) -> bool:
+    """True if a CTE named ``target`` is defined in a WITH clause attached
+    to any ``Select`` ancestor of ``table_node`` — i.e. visible per
+    standard SQL lexical scoping. Excludes the case where ``table_node``
+    is *inside* the CTE's own body (a non-recursive CTE doesn't see
+    itself; ``WITH RECURSIVE`` is rare in OMOP analytics and would
+    require deeper handling, so the simple non-recursive rule is the
+    safe default here).
+
+    Walks up through ancestor ``Select`` scopes one at a time so that
+    a CTE defined in a nested subquery is NOT mistakenly treated as
+    shadowing an outer table reference.
+    """
+    cursor: Optional[exp.Expression] = table_node
+    while cursor is not None:
+        select = cursor.find_ancestor(exp.Select)
+        if select is None:
+            return False
+        with_clause = select.args.get("with_") or select.args.get("with")
+        if with_clause is not None:
+            for cte in with_clause.expressions or []:
+                if not cte.alias or normalize_name(cte.alias) != target:
+                    continue
+                # Self-reference: a CTE doesn't shadow Table refs that
+                # live inside its own body (standard SQL, non-recursive).
+                if _is_descendant_of(table_node, cte.this):
+                    continue
+                return True
+        # Continue walking outward — but find_ancestor includes `cursor`
+        # itself if it matches, so step PAST `select` for the next round.
+        cursor = select.parent
+    return False
 
 
 def extract_aliases(tree: exp.Expression) -> Dict[str, str]:
@@ -425,9 +478,17 @@ def is_numeric_literal(e: exp.Expression, value: Optional[int] = None) -> bool:
 def has_table_reference(tree: exp.Expression, table_name: str) -> bool:
     """Check if query references a table by name anywhere.
 
-    CTE-aware: an unqualified reference whose name matches a CTE defined in
-    scope is treated as the CTE, not the OMOP table. Schema-qualified
-    references (``mydb.cohort``) still count, matching standard SQL scoping.
+    CTE-aware *per-node*: an unqualified reference whose name matches a
+    CTE visible from its lexical scope is treated as the CTE, not the
+    OMOP table. Visibility follows standard SQL scoping — a CTE is
+    visible iff it is defined in a WITH clause attached to an ancestor
+    SELECT of the reference (and the reference isn't inside the CTE's
+    own body, non-recursive case). Schema-qualified references
+    (``mydb.cohort``) always count.
+
+    The per-node check avoids a tree-global over-approximation: a CTE
+    named ``cohort`` defined inside a nested subquery does NOT shadow
+    an outer ``FROM cohort``.
 
     Args:
         tree: The SQL AST to search
@@ -437,11 +498,12 @@ def has_table_reference(tree: exp.Expression, table_name: str) -> bool:
         True if the table is referenced
     """
     target = normalize_name(table_name)
-    cte_names = collect_cte_names(tree)
     for t in tree.find_all(exp.Table):
         if normalize_name(t.name) != target:
             continue
-        if target in cte_names and not _is_schema_qualified(t):
+        if _is_schema_qualified(t):
+            return True
+        if _is_shadowed_by_visible_cte(t, target):
             continue
         return True
     return False

--- a/src/fastssv/core/helpers.py
+++ b/src/fastssv/core/helpers.py
@@ -319,6 +319,23 @@ def parse_sql(sql: str, dialect: str = "postgres") -> Tuple[Optional[List[exp.Ex
         return None, f"Unexpected error parsing SQL: {str(e)}"
 
 
+def collect_cte_names(tree: exp.Expression) -> Set[str]:
+    """Return the set of CTE names defined in any WITH clause within ``tree``.
+
+    Used by OMOP-table-targeting rules to distinguish between an actual OMOP
+    table reference and an unqualified reference to a same-named user CTE.
+    """
+    return {normalize_name(cte.alias) for cte in tree.find_all(exp.CTE) if cte.alias}
+
+
+def _is_schema_qualified(t: exp.Table) -> bool:
+    """True if a Table node carries a schema/catalog prefix (``db.tbl`` or
+    ``catalog.db.tbl``). Schema-qualified references bypass CTE shadowing
+    per standard SQL scoping rules.
+    """
+    return bool(t.args.get("db") or t.args.get("catalog"))
+
+
 def extract_aliases(tree: exp.Expression) -> Dict[str, str]:
     """Build a mapping of alias -> real_table_name.
 
@@ -408,6 +425,10 @@ def is_numeric_literal(e: exp.Expression, value: Optional[int] = None) -> bool:
 def has_table_reference(tree: exp.Expression, table_name: str) -> bool:
     """Check if query references a table by name anywhere.
 
+    CTE-aware: an unqualified reference whose name matches a CTE defined in
+    scope is treated as the CTE, not the OMOP table. Schema-qualified
+    references (``mydb.cohort``) still count, matching standard SQL scoping.
+
     Args:
         tree: The SQL AST to search
         table_name: The table name to look for
@@ -416,7 +437,14 @@ def has_table_reference(tree: exp.Expression, table_name: str) -> bool:
         True if the table is referenced
     """
     target = normalize_name(table_name)
-    return any(normalize_name(t.name) == target for t in tree.find_all(exp.Table))
+    cte_names = collect_cte_names(tree)
+    for t in tree.find_all(exp.Table):
+        if normalize_name(t.name) != target:
+            continue
+        if target in cte_names and not _is_schema_qualified(t):
+            continue
+        return True
+    return False
 
 
 def is_in_where_or_join_clause(node: exp.Expression) -> bool:
@@ -554,6 +582,7 @@ __all__ = [
     "normalize_name",
     "parse_sql",
     "extract_aliases",
+    "collect_cte_names",
     "resolve_table_col",
     "is_string_literal",
     "is_numeric_literal",

--- a/src/fastssv/rules/anti_patterns/__init__.py
+++ b/src/fastssv/rules/anti_patterns/__init__.py
@@ -25,6 +25,7 @@ from .duplicate_column_alias import DuplicateColumnAliasRule
 from .top_as_synthetic_data import TopAsSyntheticDataRule
 from .null_comparison_operator import NullComparisonOperatorRule
 from .limit_without_order_by import LimitWithoutOrderByRule
+from .cte_shadows_omop_table import CteShadowsOmopTableRule
 
 __all__ = [
     "NoStringIdentificationRule",
@@ -47,4 +48,5 @@ __all__ = [
     "TopAsSyntheticDataRule",
     "NullComparisonOperatorRule",
     "LimitWithoutOrderByRule",
+    "CteShadowsOmopTableRule",
 ]

--- a/src/fastssv/rules/anti_patterns/cte_shadows_omop_table.py
+++ b/src/fastssv/rules/anti_patterns/cte_shadows_omop_table.py
@@ -1,0 +1,133 @@
+"""CTE Shadows OMOP Table Rule.
+
+OMOP semantic rule (anti-pattern):
+Naming a CTE after an OMOP CDM table (``cohort``, ``concept``, ``person``,
+``condition_occurrence``, etc.) shadows the real OMOP table within the
+query's scope. Any unqualified reference to that name now binds to the
+CTE — not to the OMOP table — which:
+
+- Makes the query harder to read: every ``FROM cohort`` is ambiguous to a
+  reader who doesn't have the WITH-clause in mind.
+- Breaks any later edit that adds a real OMOP reference (the editor and
+  every linter will silently bind it to the CTE).
+- Produces surprising results when a suggested fix from another rule
+  ("ADD: JOIN concept c ON ...") is applied verbatim: the JOIN binds to
+  the CTE, which lacks the columns the fix assumes (``standard_concept``,
+  ``invalid_reason``, …), and execution fails with a missing-column error.
+
+The fix is purely lexical: rename the CTE to something that doesn't
+collide (``my_concepts``, ``target_cohort``, ``patient_set`` etc.).
+Schema-qualifying every OMOP reference (``FROM omop.concept``) is a
+workaround but doesn't address the readability cost — the rename is
+preferable.
+"""
+
+from typing import List
+
+from sqlglot import exp
+
+from fastssv.core.base import Rule, RuleViolation, Severity
+from fastssv.core.helpers import collect_cte_names, normalize_name, parse_sql
+from fastssv.core.registry import register
+from fastssv.schemas import CDM_COLUMN_TYPES
+
+
+_OMOP_TABLE_NAMES = frozenset(normalize_name(t) for t in CDM_COLUMN_TYPES)
+
+
+@register
+class CteShadowsOmopTableRule(Rule):
+    """Warn when a CTE's alias collides with an OMOP CDM table name."""
+
+    rule_id = "anti_patterns.cte_shadows_omop_table"
+    name = "CTE Shadows OMOP CDM Table Name"
+
+    description = (
+        "A CTE whose alias matches an OMOP CDM table name (e.g. `WITH cohort AS …`, "
+        "`WITH concept AS …`) shadows the real OMOP table within the query. "
+        "Subsequent unqualified references bind to the CTE, not the OMOP table — "
+        "a frequent source of confusion and broken downstream rule fixes."
+    )
+
+    severity = Severity.WARNING
+
+    suggested_fix = (
+        "RENAME: the CTE to a non-colliding name (e.g. `WITH my_concepts AS …` instead of "
+        "`WITH concept AS …`). If renaming is impractical, every OMOP reference inside the "
+        "query must be schema-qualified (`omop.concept` rather than `concept`)."
+    )
+
+    example_bad = (
+        "WITH concept AS (\n"
+        "    SELECT 4112343 AS concept_id UNION ALL SELECT 201826\n"
+        ")\n"
+        "SELECT co.person_id\n"
+        "FROM condition_occurrence co\n"
+        "JOIN concept ON co.condition_concept_id = concept.concept_id;"
+    )
+    example_good = (
+        "WITH my_concepts AS (\n"
+        "    SELECT 4112343 AS concept_id UNION ALL SELECT 201826\n"
+        ")\n"
+        "SELECT co.person_id\n"
+        "FROM condition_occurrence co\n"
+        "JOIN my_concepts ON co.condition_concept_id = my_concepts.concept_id;"
+    )
+
+    def validate(self, sql: str, dialect: str = "postgres") -> List[RuleViolation]:
+        if not sql:
+            return []
+
+        # Fast pre-filter — no CTE means no shadow.
+        sql_lower = sql.lower()
+        if "with" not in sql_lower:
+            return []
+
+        trees, error = parse_sql(sql, dialect)
+        if error:
+            return []
+
+        violations: List[RuleViolation] = []
+        seen: set = set()
+
+        for tree in trees:
+            if tree is None:
+                continue
+
+            # Single source of truth for "what CTEs exist in scope" — the
+            # same helper used by ~30 OMOP-table-targeting rules to suppress
+            # downstream FPs on these shadows.
+            shadows = collect_cte_names(tree) & _OMOP_TABLE_NAMES
+            if not shadows:
+                continue
+
+            # Walk CTE nodes only to recover the *original* alias casing
+            # (collect_cte_names returns the normalized set); membership is
+            # already decided by the intersection above.
+            for cte in tree.find_all(exp.CTE):
+                if not cte.alias:
+                    continue
+                name_norm = normalize_name(cte.alias)
+                if name_norm not in shadows:
+                    continue
+                if name_norm in seen:
+                    continue
+                seen.add(name_norm)
+
+                violations.append(
+                    self.create_violation(
+                        message=(
+                            f"CTE named `{cte.alias}` shadows the OMOP CDM table `{name_norm}`. "
+                            f"Unqualified references to `{name_norm}` within this query bind to "
+                            f"the CTE, not the OMOP table — rename the CTE to avoid confusion "
+                            f"and to keep suggested fixes from other rules executable."
+                        ),
+                        severity=self.severity,
+                        details={"cte_name": cte.alias, "omop_table": name_norm},
+                    )
+                )
+
+        return violations
+
+
+__all__ = ["CteShadowsOmopTableRule"]

--- a/src/fastssv/rules/anti_patterns/cte_shadows_omop_table.py
+++ b/src/fastssv/rules/anti_patterns/cte_shadows_omop_table.py
@@ -1,22 +1,31 @@
-"""CTE Shadows OMOP Table Rule.
+"""CTE / Subquery-Alias Shadows OMOP Table Rule.
 
 OMOP semantic rule (anti-pattern):
-Naming a CTE after an OMOP CDM table (``cohort``, ``concept``, ``person``,
-``condition_occurrence``, etc.) shadows the real OMOP table within the
-query's scope. Any unqualified reference to that name now binds to the
-CTE — not to the OMOP table — which:
+Naming a CTE OR a derived-table subquery alias after an OMOP CDM table
+(``cohort``, ``concept``, ``person``, ``condition_occurrence``, etc.)
+re-uses the OMOP name for a local construct within the query.
 
-- Makes the query harder to read: every ``FROM cohort`` is ambiguous to a
-  reader who doesn't have the WITH-clause in mind.
-- Breaks any later edit that adds a real OMOP reference (the editor and
-  every linter will silently bind it to the CTE).
-- Produces surprising results when a suggested fix from another rule
-  ("ADD: JOIN concept c ON ...") is applied verbatim: the JOIN binds to
+For **CTEs** (``WITH concept AS …``), the alias is visible to every
+sibling FROM clause in the query, so the harms are severe:
+
+- Readability: every ``FROM concept`` is ambiguous to a reader who
+  doesn't have the WITH-clause in mind.
+- Edit hazard: a later real OMOP reference silently binds to the CTE.
+- **Downstream fix breakage**: a suggested fix from another rule
+  ("ADD: JOIN concept c ON ...") is applied verbatim, the JOIN binds to
   the CTE, which lacks the columns the fix assumes (``standard_concept``,
   ``invalid_reason``, …), and execution fails with a missing-column error.
 
-The fix is purely lexical: rename the CTE to something that doesn't
-collide (``my_concepts``, ``target_cohort``, ``patient_set`` etc.).
+For **derived-table subqueries** (``FROM (SELECT …) AS concept``), the
+alias is scope-local — sibling FROM items don't see it — so the third
+harm (downstream-fix breakage) does NOT apply: a ``JOIN concept c``
+introduced anywhere else in the query resolves to OMOP ``concept``, not
+the subquery. But the readability and edit-hazard concerns still hold,
+which is why we still flag these (with a tuned message that drops the
+breakage framing).
+
+The fix is purely lexical: rename the CTE or alias to something that
+doesn't collide (``my_concepts``, ``target_cohort``, ``patient_set``).
 Schema-qualifying every OMOP reference (``FROM omop.concept``) is a
 workaround but doesn't address the readability cost — the rename is
 preferable.
@@ -37,24 +46,28 @@ _OMOP_TABLE_NAMES = frozenset(normalize_name(t) for t in CDM_COLUMN_TYPES)
 
 @register
 class CteShadowsOmopTableRule(Rule):
-    """Warn when a CTE's alias collides with an OMOP CDM table name."""
+    """Warn when a CTE alias OR a derived-table subquery alias collides
+    with an OMOP CDM table name."""
 
     rule_id = "anti_patterns.cte_shadows_omop_table"
-    name = "CTE Shadows OMOP CDM Table Name"
+    name = "CTE or Subquery Alias Shadows OMOP CDM Table"
 
     description = (
-        "A CTE whose alias matches an OMOP CDM table name (e.g. `WITH cohort AS …`, "
-        "`WITH concept AS …`) shadows the real OMOP table within the query. "
-        "Subsequent unqualified references bind to the CTE, not the OMOP table — "
-        "a frequent source of confusion and broken downstream rule fixes."
+        "A CTE or derived-table subquery whose alias matches an OMOP CDM table "
+        "name (e.g. `WITH concept AS …` or `FROM (SELECT …) AS concept`) re-uses "
+        "an OMOP name for a local construct. For CTEs this also breaks suggested "
+        "fixes from other rules (the JOIN binds to the CTE, which lacks OMOP "
+        "columns); for derived-table subqueries the harm is limited to readability "
+        "and edit hazards, but the rename is still the right call."
     )
 
     severity = Severity.WARNING
 
     suggested_fix = (
-        "RENAME: the CTE to a non-colliding name (e.g. `WITH my_concepts AS …` instead of "
-        "`WITH concept AS …`). If renaming is impractical, every OMOP reference inside the "
-        "query must be schema-qualified (`omop.concept` rather than `concept`)."
+        "RENAME: the CTE or derived-table alias to a non-colliding name "
+        "(e.g. `WITH my_concepts AS …` or `FROM (SELECT …) AS my_concepts`, "
+        "instead of `concept`). If renaming is impractical, every OMOP reference "
+        "inside the query must be schema-qualified (`omop.concept` rather than `concept`)."
     )
 
     example_bad = (
@@ -78,9 +91,11 @@ class CteShadowsOmopTableRule(Rule):
         if not sql:
             return []
 
-        # Fast pre-filter — no CTE means no shadow.
+        # Fast pre-filter — no CTE keyword AND no parenthesis means no
+        # derived-table subquery either. Trivial queries like `SELECT 1`
+        # and `SELECT * FROM t` short-circuit here without parsing.
         sql_lower = sql.lower()
-        if "with" not in sql_lower:
+        if "with" not in sql_lower and "(" not in sql_lower:
             return []
 
         trees, error = parse_sql(sql, dialect)
@@ -88,42 +103,91 @@ class CteShadowsOmopTableRule(Rule):
             return []
 
         violations: List[RuleViolation] = []
+        # Dedup key is (kind, normalized-name): a single SQL string with
+        # both a CTE named `cohort` and a derived-table aliased `cohort`
+        # (legal across nested scopes) emits one warning per kind.
         seen: set = set()
 
         for tree in trees:
             if tree is None:
                 continue
 
-            # Single source of truth for "what CTEs exist in scope" — the
-            # same helper used by ~30 OMOP-table-targeting rules to suppress
-            # downstream FPs on these shadows.
+            # --- CTEs ----------------------------------------------------
+            # `collect_cte_names` is intentionally tree-global here: every
+            # CTE in the SQL contributes a shadow regardless of its lexical
+            # depth, because the rename advice applies uniformly. The
+            # scope-aware version (`has_table_reference` in helpers.py) is
+            # for the *opposite* question: "is this Table reference
+            # shadowed by a visible CTE?".
             shadows = collect_cte_names(tree) & _OMOP_TABLE_NAMES
-            if not shadows:
-                continue
+            if shadows:
+                # Walk CTE nodes to recover the *original* alias casing
+                # (collect_cte_names returns the normalized set).
+                for cte in tree.find_all(exp.CTE):
+                    if not cte.alias:
+                        continue
+                    name_norm = normalize_name(cte.alias)
+                    if name_norm not in shadows:
+                        continue
+                    key = ("cte", name_norm)
+                    if key in seen:
+                        continue
+                    seen.add(key)
 
-            # Walk CTE nodes only to recover the *original* alias casing
-            # (collect_cte_names returns the normalized set); membership is
-            # already decided by the intersection above.
-            for cte in tree.find_all(exp.CTE):
-                if not cte.alias:
+                    violations.append(
+                        self.create_violation(
+                            message=(
+                                f"CTE named `{cte.alias}` shadows the OMOP CDM table "
+                                f"`{name_norm}`. Unqualified references to `{name_norm}` "
+                                f"within this query bind to the CTE, not the OMOP table — "
+                                f"rename the CTE to avoid confusion and to keep suggested "
+                                f"fixes from other rules executable."
+                            ),
+                            severity=self.severity,
+                            details={
+                                "alias_kind": "cte",
+                                "alias": cte.alias,
+                                "cte_name": cte.alias,
+                                "omop_table": name_norm,
+                            },
+                        )
+                    )
+
+            # --- Derived-table subqueries -------------------------------
+            # `exp.Subquery` covers `FROM (SELECT …) AS x` and the JOIN
+            # equivalent. Scalar subqueries in SELECT (`SELECT (SELECT …)
+            # AS x FROM …`) keep their alias on the outer `exp.Alias`
+            # wrapper, not the Subquery itself, so `sub.alias` is empty
+            # there and the filter naturally excludes them. Anonymous
+            # subqueries in WHERE IN / EXISTS predicates have no alias
+            # at all and are likewise skipped.
+            for sub in tree.find_all(exp.Subquery):
+                alias = sub.alias
+                if not alias:
                     continue
-                name_norm = normalize_name(cte.alias)
-                if name_norm not in shadows:
+                name_norm = normalize_name(alias)
+                if name_norm not in _OMOP_TABLE_NAMES:
                     continue
-                if name_norm in seen:
+                key = ("subquery", name_norm)
+                if key in seen:
                     continue
-                seen.add(name_norm)
+                seen.add(key)
 
                 violations.append(
                     self.create_violation(
                         message=(
-                            f"CTE named `{cte.alias}` shadows the OMOP CDM table `{name_norm}`. "
-                            f"Unqualified references to `{name_norm}` within this query bind to "
-                            f"the CTE, not the OMOP table — rename the CTE to avoid confusion "
-                            f"and to keep suggested fixes from other rules executable."
+                            f"Subquery aliased `{alias}` reuses the OMOP CDM table name "
+                            f"`{name_norm}`. References like `{name_norm}.<col>` in this "
+                            f"query block resolve to the derived table, not the OMOP "
+                            f"table — rename the alias to avoid the readability cost when "
+                            f"scanning the query."
                         ),
                         severity=self.severity,
-                        details={"cte_name": cte.alias, "omop_table": name_norm},
+                        details={
+                            "alias_kind": "subquery",
+                            "alias": alias,
+                            "omop_table": name_norm,
+                        },
                     )
                 )
 

--- a/src/fastssv/rules/anti_patterns/limit_without_order_by.py
+++ b/src/fastssv/rules/anti_patterns/limit_without_order_by.py
@@ -91,15 +91,39 @@ def _projection_contains_bare_column(expr: exp.Expression) -> bool:
     return False
 
 
+def _projection_contains_window(expr: exp.Expression) -> bool:
+    """True if ``expr`` contains a window function (``f(...) OVER (...)``).
+
+    Window functions are *per-row* — they compute over a frame but produce
+    one output row per input row, so a SELECT with any window projection
+    cannot be a scalar aggregation no matter what aggregates appear
+    inside the OVER. sqlglot parses ``SUM(x) OVER (...)`` as an
+    ``exp.Window`` node *wrapping* an ``exp.AggFunc`` (the inner Sum),
+    so an earlier draft of ``_is_scalar_aggregate`` mistook the inner
+    aggregate as evidence of scalar-agg and suppressed the LIMIT warning
+    incorrectly (caught in code review). We treat any Window in the
+    projection as a hard veto.
+    """
+    if isinstance(expr, exp.Window):
+        return True
+    for node in expr.find_all(exp.Window):
+        if _is_inside_inner_subquery(node, expr):
+            continue
+        return True
+    return False
+
+
 def _is_scalar_aggregate(select: exp.Select) -> bool:
     """True if ``select`` provably returns exactly one row.
 
-    Scalar aggregation has no ``GROUP BY`` / ``HAVING``, at least one
-    projection contains an aggregate, and no projection has a bare
-    (non-aggregated) column reference. In that shape, ``LIMIT N`` is a
-    no-op — ordering is irrelevant — so the missing-ORDER-BY warning
-    would be a false positive. ``SELECT COUNT(DISTINCT x) FROM ... LIMIT 1000``
-    is the canonical Atlas/OHDSI pattern this skips.
+    Scalar aggregation has no ``GROUP BY`` / ``HAVING``, no window
+    functions in any projection (windowed aggregates are per-row, not
+    row-collapsing), at least one projection contains a non-windowed
+    aggregate, and no projection has a bare (non-aggregated) column
+    reference. In that shape, ``LIMIT N`` is a no-op — ordering is
+    irrelevant — so the missing-ORDER-BY warning would be a false
+    positive. ``SELECT COUNT(DISTINCT x) FROM ... LIMIT 1000`` is the
+    canonical Atlas/OHDSI pattern this skips.
     """
     if select.args.get("group") is not None:
         return False
@@ -112,6 +136,9 @@ def _is_scalar_aggregate(select: exp.Select) -> bool:
     for proj in select.expressions:
         expr = proj.this if isinstance(proj, exp.Alias) else proj
         if isinstance(expr, exp.Star):
+            return False
+        # Veto: any window function makes the SELECT non-scalar.
+        if _projection_contains_window(expr):
             return False
         if _projection_contains_agg(expr):
             has_any_agg = True

--- a/src/fastssv/rules/anti_patterns/limit_without_order_by.py
+++ b/src/fastssv/rules/anti_patterns/limit_without_order_by.py
@@ -45,6 +45,81 @@ def _is_inside_existence_predicate(select: exp.Select) -> bool:
     return False
 
 
+def _is_inside_inner_subquery(node: exp.Expression, root: exp.Expression) -> bool:
+    """True if ``node`` is enclosed by an ``exp.Subquery`` that is a strict
+    descendant of ``root`` — used to scope walks to a single projection
+    expression without leaking into scalar subqueries inside it.
+    """
+    cursor = node.parent
+    while cursor is not None and cursor is not root:
+        if isinstance(cursor, exp.Subquery):
+            return True
+        cursor = cursor.parent
+    return False
+
+
+def _projection_contains_agg(expr: exp.Expression) -> bool:
+    """True if any aggregate function appears within ``expr``, ignoring
+    aggregates that live inside scalar subqueries (those don't aggregate
+    the outer SELECT's rows)."""
+    if isinstance(expr, exp.AggFunc):
+        return True
+    for node in expr.find_all(exp.AggFunc):
+        if _is_inside_inner_subquery(node, expr):
+            continue
+        return True
+    return False
+
+
+def _projection_contains_bare_column(expr: exp.Expression) -> bool:
+    """True if ``expr`` has a Column reference that is NOT wrapped by an
+    aggregate (within ``expr``) and NOT inside a scalar subquery. A bare
+    column reference makes the result multi-row, defeating scalar-agg
+    suppression."""
+    for col in expr.find_all(exp.Column):
+        if _is_inside_inner_subquery(col, expr):
+            continue
+        cursor = col.parent
+        inside_agg = False
+        while cursor is not None and cursor is not expr.parent:
+            if isinstance(cursor, exp.AggFunc):
+                inside_agg = True
+                break
+            cursor = cursor.parent
+        if not inside_agg:
+            return True
+    return False
+
+
+def _is_scalar_aggregate(select: exp.Select) -> bool:
+    """True if ``select`` provably returns exactly one row.
+
+    Scalar aggregation has no ``GROUP BY`` / ``HAVING``, at least one
+    projection contains an aggregate, and no projection has a bare
+    (non-aggregated) column reference. In that shape, ``LIMIT N`` is a
+    no-op — ordering is irrelevant — so the missing-ORDER-BY warning
+    would be a false positive. ``SELECT COUNT(DISTINCT x) FROM ... LIMIT 1000``
+    is the canonical Atlas/OHDSI pattern this skips.
+    """
+    if select.args.get("group") is not None:
+        return False
+    if select.args.get("having") is not None:
+        return False
+    if not select.expressions:
+        return False
+
+    has_any_agg = False
+    for proj in select.expressions:
+        expr = proj.this if isinstance(proj, exp.Alias) else proj
+        if isinstance(expr, exp.Star):
+            return False
+        if _projection_contains_agg(expr):
+            has_any_agg = True
+        if _projection_contains_bare_column(expr):
+            return False
+    return has_any_agg
+
+
 def _select_has_explicit_limit(select: exp.Select) -> Optional[str]:
     """Return a short SQL fragment describing the row-limiting clause if
     one is present (LIMIT, FETCH FIRST, or T-SQL TOP), else None.
@@ -137,6 +212,9 @@ class LimitWithoutOrderByRule(Rule):
                     continue
 
                 if _select_has_order_by(select):
+                    continue
+
+                if _is_scalar_aggregate(select):
                     continue
 
                 # Use the SELECT's text fingerprint so we don't double-fire

--- a/src/fastssv/rules/concept_standardization/standard_concept_enforcement.py
+++ b/src/fastssv/rules/concept_standardization/standard_concept_enforcement.py
@@ -13,7 +13,6 @@ from sqlglot import exp
 
 from fastssv.core.base import Rule, RuleViolation, Severity
 from fastssv.core.helpers import (
-    collect_cte_names,
     has_condition,
     extract_aliases,
     extract_join_conditions,
@@ -431,13 +430,27 @@ class StandardConceptEnforcementRule(Rule):
                     message += " (Strict mode: cohort definitions must use standard concepts)"
 
                 # CTE-shadow aware suggested fix: if the user has a CTE named
-                # `concept` (or `concept_relationship`) in scope, the default
-                # `JOIN concept c ...` suggestion would resolve to that CTE
-                # — which has no `standard_concept` column — and break at
+                # `concept` (or `concept_relationship`) *at the top level of
+                # the statement*, the default `JOIN concept c ...` suggestion
+                # — applied at that same top level — would resolve to that
+                # CTE, which has no `standard_concept` column, and break at
                 # execution time. Switch to the schema-qualified form and
                 # flag the shadow so the user sees the actual root cause.
-                cte_names = collect_cte_names(tree)
-                shadow = cte_names & {"concept", "concept_relationship"}
+                #
+                # Scope deliberately restricted to the *top-level* WITH:
+                # CTEs defined inside a nested subquery (e.g. inside an IN /
+                # EXISTS / FROM-derived) are lexically out of scope for a
+                # JOIN added at the outer SELECT, so the generic fix is
+                # already executable in that case. The broader tree-global
+                # "any matching CTE anywhere" signal is handled by the
+                # `anti_patterns.cte_shadows_omop_table` rule independently.
+                top_with = tree.args.get("with_") or tree.args.get("with")
+                top_cte_names: Set[str] = set()
+                if top_with is not None:
+                    for top_cte in top_with.expressions or []:
+                        if top_cte.alias:
+                            top_cte_names.add(normalize_name(top_cte.alias))
+                shadow = top_cte_names & {"concept", "concept_relationship"}
                 if shadow:
                     shadow_list = ", ".join(sorted(shadow))
                     suggested_fix = (

--- a/src/fastssv/rules/concept_standardization/standard_concept_enforcement.py
+++ b/src/fastssv/rules/concept_standardization/standard_concept_enforcement.py
@@ -13,6 +13,7 @@ from sqlglot import exp
 
 from fastssv.core.base import Rule, RuleViolation, Severity
 from fastssv.core.helpers import (
+    collect_cte_names,
     has_condition,
     extract_aliases,
     extract_join_conditions,
@@ -429,11 +430,35 @@ class StandardConceptEnforcementRule(Rule):
                 if severity == Severity.ERROR:
                     message += " (Strict mode: cohort definitions must use standard concepts)"
 
+                # CTE-shadow aware suggested fix: if the user has a CTE named
+                # `concept` (or `concept_relationship`) in scope, the default
+                # `JOIN concept c ...` suggestion would resolve to that CTE
+                # — which has no `standard_concept` column — and break at
+                # execution time. Switch to the schema-qualified form and
+                # flag the shadow so the user sees the actual root cause.
+                cte_names = collect_cte_names(tree)
+                shadow = cte_names & {"concept", "concept_relationship"}
+                if shadow:
+                    shadow_list = ", ".join(sorted(shadow))
+                    suggested_fix = (
+                        "ADD: `JOIN omop.concept c ON c.concept_id = <table>.<concept_id_col>` "
+                        "AND `WHERE c.standard_concept = 'S'` to filter to standard concepts. "
+                        f"NOTE: this query has a CTE named `{shadow_list}` which shadows the OMOP "
+                        "vocabulary table — the JOIN must be schema-qualified (`omop.concept`) "
+                        "or the CTE renamed, otherwise the JOIN would bind to the CTE and the "
+                        "`standard_concept` column would not exist."
+                    )
+                else:
+                    suggested_fix = (
+                        "ADD: `JOIN concept c ON c.concept_id = <table>.<concept_id_col>` "
+                        "AND `WHERE c.standard_concept = 'S'` to filter to standard concepts."
+                    )
+
                 violations.append(
                     self.create_violation(
                         message=message,
                         severity=severity,
-                        suggested_fix="ADD: `JOIN concept c ON c.concept_id = <table>.<concept_id_col>` AND `WHERE c.standard_concept = 'S'` to filter to standard concepts.",
+                        suggested_fix=suggested_fix,
                         details={"strict_mode_escalated": severity == Severity.ERROR},
                     )
                 )

--- a/src/fastssv/rules/data_quality/comprehensive_schema_validation.py
+++ b/src/fastssv/rules/data_quality/comprehensive_schema_validation.py
@@ -8,11 +8,11 @@ Source of truth is ``fastssv.schemas.CDM_COLUMN_TYPES``; this rule reads
 it through the package boundary.
 """
 
-from typing import List, Set
+from typing import Dict, List, Optional, Set
 from sqlglot import exp
 
 from fastssv.core.base import Rule, RuleViolation, Severity
-from fastssv.core.helpers import extract_aliases, normalize_name, parse_sql
+from fastssv.core.helpers import normalize_name, parse_sql
 from fastssv.core.patch import locate, replace as patch_replace
 from fastssv.core.registry import register
 from fastssv.schemas import CDM_COLUMN_TYPES, get_table_columns
@@ -62,6 +62,111 @@ def _extract_subquery_aliases(tree: exp.Expression) -> Set[str]:
         if subquery.alias:
             subquery_aliases.add(_norm(subquery.alias))
     return subquery_aliases
+
+
+_TIME_UNIT_KEYWORDS = frozenset(
+    {
+        "day",
+        "days",
+        "month",
+        "months",
+        "year",
+        "years",
+        "hour",
+        "hours",
+        "minute",
+        "minutes",
+        "second",
+        "seconds",
+        "week",
+        "weeks",
+        "quarter",
+        "quarters",
+        "millisecond",
+        "milliseconds",
+        "microsecond",
+        "microseconds",
+        "nanosecond",
+        "nanoseconds",
+        "epoch",
+    }
+)
+_DATE_FN_TYPES = (
+    exp.DateDiff,
+    exp.DateAdd,
+    exp.DateSub,
+    exp.DateTrunc,
+    exp.TimestampDiff,
+    exp.TimestampAdd,
+    exp.TimestampSub,
+    exp.Extract,
+)
+
+
+def _is_time_unit_arg(column: exp.Column) -> bool:
+    """True for unqualified ``Column`` nodes that are actually unit keywords
+    (``day``, ``month`` …) inside a date function. sqlglot parses
+    ``DATEDIFF(day, x, y)`` with ``day`` as a ``Column`` node; treating it
+    as a real column reference yields false-positive
+    "Column 'day' does not exist in table …" errors.
+    """
+    if column.table:
+        return False
+    if column.name.lower() not in _TIME_UNIT_KEYWORDS:
+        return False
+    parent = column.parent
+    return isinstance(parent, _DATE_FN_TYPES)
+
+
+def _local_aliases(select: exp.Select) -> Dict[str, str]:
+    """Aliases declared by ``select``'s own FROM/JOIN — excluding tables
+    nested inside subqueries or further CTE bodies inside this scope.
+
+    Required because a query that reuses an alias across CTEs (`omop.concept c`
+    in one CTE, `cond_occ c` in the outer SELECT) collapses under the global
+    ``extract_aliases`` — last-write-wins on a flat dict — which then
+    misattributes column references and yields false-positive
+    "column does not exist in table X" errors.
+    """
+    aliases: Dict[str, str] = {}
+    from_node = select.args.get("from_") or select.args.get("from")
+    scopes = [from_node] + list(select.args.get("joins") or [])
+    for scope_node in scopes:
+        if scope_node is None:
+            continue
+        for tbl in scope_node.find_all(exp.Table):
+            # Restrict to tables whose immediate enclosing Select is `select`
+            # (i.e. not buried in a Subquery or nested SELECT inside this scope).
+            if tbl.find_ancestor(exp.Select) is not select:
+                continue
+            real = _norm(tbl.name)
+            alias = tbl.alias_or_name
+            if alias:
+                aliases[_norm(alias)] = real
+            aliases[real] = real
+    return aliases
+
+
+def _resolve_column_table(column: exp.Column) -> Optional[str]:
+    """Resolve ``column.table`` to a real table name using scope-local aliases.
+
+    Walks up enclosing ``Select`` scopes (innermost first) so correlated
+    subqueries can still see outer-scope aliases, but inner scopes shadow.
+    Returns ``None`` if no enclosing Select exists; returns the literal
+    table_ref if it isn't bound by any visible alias (the caller decides
+    whether to treat that as an unknown table).
+    """
+    table_ref = _norm(column.table) if column.table else None
+    if not table_ref:
+        return None
+
+    select = column.find_ancestor(exp.Select)
+    while select is not None:
+        local = _local_aliases(select)
+        if table_ref in local:
+            return local[table_ref]
+        select = select.find_ancestor(exp.Select)
+    return table_ref
 
 
 def _extract_select_aliases(tree: exp.Expression) -> Set[str]:
@@ -135,11 +240,13 @@ class ComprehensiveSchemaValidationRule(Rule):
             if not tree:
                 continue
 
-            # Extract CTEs, subqueries, and aliases for scope awareness
+            # Extract CTEs, subqueries, and SELECT aliases for scope awareness.
+            # Column resolution uses _resolve_column_table for scope-local lookup
+            # (the global extract_aliases is intentionally not used here — it
+            # collapses reused aliases across CTEs).
             cte_names = _extract_cte_names(tree)
             subquery_aliases = _extract_subquery_aliases(tree)
             select_aliases = _extract_select_aliases(tree)
-            table_aliases = extract_aliases(tree)
 
             # Track which tables/columns we've already reported to avoid duplicates
             reported_tables = set()
@@ -209,24 +316,26 @@ class ComprehensiveSchemaValidationRule(Rule):
                 if col_name in select_aliases:
                     continue
 
+                # Skip unit keywords that sqlglot parses as Column nodes
+                # (e.g. ``DATEDIFF(day, ...)`` -> Column(day) inside DateDiff).
+                if _is_time_unit_arg(column):
+                    continue
+
                 # Get table reference
                 table_ref = _norm(column.table) if column.table else None
 
-                # Resolve table name through aliases
+                # Resolve table name through scope-local aliases.
                 if table_ref:
-                    # Check if this is a CTE or subquery
+                    # Skip CTE / subquery references at the alias-name layer.
                     if table_ref in cte_names or table_ref in subquery_aliases:
                         continue
 
-                    if table_ref in table_aliases:
-                        resolved_table = _norm(table_aliases[table_ref])
-                        # Handle schema-qualified tables
-                        if "." in resolved_table:
-                            resolved_table = resolved_table.split(".")[-1]
-                    else:
-                        resolved_table = table_ref
+                    resolved_table = _resolve_column_table(column) or table_ref
+                    if "." in resolved_table:
+                        resolved_table = resolved_table.split(".")[-1]
 
-                    # Skip if resolved table is a CTE or subquery
+                    # After resolution, the underlying name may itself be a
+                    # CTE / subquery (alias points at one).
                     if resolved_table in cte_names or resolved_table in subquery_aliases:
                         continue
                 else:

--- a/src/fastssv/rules/joins/join_path_validation.py
+++ b/src/fastssv/rules/joins/join_path_validation.py
@@ -39,6 +39,46 @@ def _extract_concept_references(tree: exp.Expression, aliases: Dict[str, str]) -
     return refs
 
 
+def _has_in_subquery_bridge_to_vocab_cte(
+    tree: exp.Expression,
+    vocab_cte_names: Set[str],
+) -> bool:
+    """Recognize ``WHERE x_concept_id IN (SELECT ... FROM <vocab_cte>)`` as a
+    valid CTE-mediated bridge between clinical and vocabulary tables.
+
+    The pre-existing CTE-bridge check only inspects ``JOIN ... ON``
+    equalities (via :func:`extract_join_conditions`), which misses the
+    canonical Atlas/OHDSI shape::
+
+        WITH vocab_cte AS (SELECT concept_id FROM concept WHERE ...)
+        SELECT ... FROM drug_exposure de
+        WHERE de.drug_concept_id IN (SELECT concept_id FROM vocab_cte)
+
+    sqlglot parses ``IN (SELECT ...)`` as ``exp.In(this=Column, query=Select)``
+    — the subquery is on the ``query`` arg rather than wrapped in a
+    ``Subquery`` node, so we read it directly.
+    """
+    for in_node in tree.find_all(exp.In):
+        lhs = in_node.this
+        if not isinstance(lhs, exp.Column):
+            continue
+        col_name = normalize_name(lhs.name)
+        if not (col_name == "concept_id" or col_name.endswith("_concept_id")):
+            continue
+        subq = in_node.args.get("query")
+        if subq is None:
+            for x in in_node.args.get("expressions") or []:
+                if isinstance(x, exp.Subquery):
+                    subq = x
+                    break
+        if subq is None:
+            continue
+        for t in subq.find_all(exp.Table):
+            if normalize_name(t.name) in vocab_cte_names:
+                return True
+    return False
+
+
 def _vocab_table_used_only_in_subquery(
     tree: exp.Expression,
     table_name: str,
@@ -165,6 +205,11 @@ def _verify_concept_join_path(
     # If there are CTEs that bridge vocabulary tables to concept_ids,
     # check if those CTEs are joined to clinical tables
     if ctes_with_vocab_and_concept_id:
+        # IN-subquery bridge: `WHERE <clinical>_concept_id IN (SELECT ... FROM <vocab_cte>)`.
+        # This is the canonical Atlas/OHDSI shape and was previously missed.
+        if _has_in_subquery_bridge_to_vocab_cte(tree, ctes_with_vocab_and_concept_id):
+            return []
+
         join_conditions = extract_join_conditions(tree, aliases)
 
         for lt, lc, rt, rc in join_conditions:

--- a/src/fastssv/rules/joins/left_join_then_where_on_right_table.py
+++ b/src/fastssv/rules/joins/left_join_then_where_on_right_table.py
@@ -87,12 +87,7 @@ from typing import Dict, List, Optional, Set, Tuple
 from sqlglot import exp
 
 from fastssv.core.base import Rule, RuleViolation, Severity
-from fastssv.core.helpers import (
-    extract_aliases,
-    normalize_name,
-    parse_sql,
-    resolve_table_col,
-)
+from fastssv.core.helpers import normalize_name, parse_sql
 from fastssv.core.registry import register
 
 
@@ -110,21 +105,6 @@ def _extract_cte_names(tree: exp.Expression) -> Set[str]:
     return {_norm(cte.alias_or_name) for cte in tree.find_all(exp.CTE) if cte.alias_or_name}
 
 
-def _resolve_column(
-    column: exp.Column,
-    aliases: Dict[str, str],
-    cte_names: Set[str],
-) -> Tuple[Optional[str], Optional[str]]:
-    table, col = resolve_table_col(column, aliases)
-    table = _norm(table)
-    col = _norm(col)
-
-    if table in cte_names:
-        return None, None
-
-    return table, col
-
-
 def _is_left_join(join: exp.Join) -> bool:
     """
     Robust LEFT JOIN detection across dialects.
@@ -135,32 +115,55 @@ def _is_left_join(join: exp.Join) -> bool:
     return (kind and _norm(kind) == "left") or (side and _norm(side) == "left")
 
 
-def _get_right_table(join: exp.Join) -> Optional[str]:
+def _local_aliases(select: exp.Select) -> Dict[str, str]:
+    """Aliases declared by ``select``'s own FROM/JOIN — excluding tables
+    nested inside subqueries or further CTE bodies inside this scope.
+
+    Mirrors the scope-local helper in ``comprehensive_schema_validation``.
+    Required because the global ``extract_aliases`` would let a LEFT JOIN
+    in one CTE alias-collide with a WHERE in another scope, producing
+    false-positive "LEFT JOIN + WHERE on right table" reports.
     """
-    Get right table or alias (no mutation of alias map).
+    aliases: Dict[str, str] = {}
+    from_node = select.args.get("from_") or select.args.get("from")
+    scopes: List[exp.Expression] = []
+    if from_node is not None:
+        scopes.append(from_node)
+    scopes.extend(select.args.get("joins") or [])
+    for scope_node in scopes:
+        for tbl in scope_node.find_all(exp.Table):
+            if tbl.find_ancestor(exp.Select) is not select:
+                continue
+            real = _norm(tbl.name) or ""
+            alias = tbl.alias_or_name
+            if alias:
+                alias_norm = _norm(alias)
+                if alias_norm:
+                    aliases[alias_norm] = real
+            if real:
+                aliases[real] = real
+    return aliases
+
+
+def _select_left_join_right_tables(select: exp.Select) -> Tuple[Set[str], Set[str]]:
+    """Return (right_aliases, right_real_names) for LEFT JOINs declared
+    directly on ``select`` — does not descend into subqueries or nested CTE
+    bodies.
     """
-    if isinstance(join.this, exp.Table):
-        return _norm(join.this.alias_or_name)
-    return None
-
-
-def _collect_left_join_right_tables(tree: exp.Expression, aliases: Dict[str, str]) -> Set[str]:
-    """Collect all right table names/aliases from LEFT JOINs."""
-    right_tables = set()
-
-    for join in tree.find_all(exp.Join):
+    right_aliases: Set[str] = set()
+    right_real_names: Set[str] = set()
+    for join in select.args.get("joins") or []:
         if not _is_left_join(join):
             continue
-
-        t = _get_right_table(join)
-        if t:
-            right_tables.add(t)
-            # Also add resolved table name if it's an alias
-            resolved = aliases.get(t)
-            if resolved and resolved != t:
-                right_tables.add(resolved)
-
-    return right_tables
+        if not isinstance(join.this, exp.Table):
+            continue
+        alias = _norm(join.this.alias_or_name)
+        real = _norm(join.this.name)
+        if alias:
+            right_aliases.add(alias)
+        if real:
+            right_real_names.add(real)
+    return right_aliases, right_real_names
 
 
 def _is_safe_null_check(node: exp.Expression) -> bool:
@@ -182,9 +185,11 @@ def _contains_or(node: exp.Expression) -> bool:
 
 
 def _collect_where_right_table_filters(
+    select: exp.Select,
     where_clause: exp.Expression,
-    right_tables: Set[str],
-    aliases: Dict[str, str],
+    right_aliases: Set[str],
+    right_real_names: Set[str],
+    local_aliases: Dict[str, str],
     cte_names: Set[str],
 ) -> List[str]:
     violations = []
@@ -205,37 +210,56 @@ def _collect_where_right_table_filters(
             continue
 
         for col in cond.find_all(exp.Column):
-            t, c = _resolve_column(col, aliases, cte_names)
-
-            if not t or not c:
+            # Columns nested inside a subquery belong to that subquery's
+            # scope — they must not be matched against THIS select's
+            # LEFT JOIN right-tables.
+            if col.find_ancestor(exp.Select) is not select:
                 continue
 
-            # Check alias or table name
-            if t in right_tables:
-                violations.append(f"{t}.{c}")
+            raw = _norm(col.table) if col.table else None
+            if not raw:
+                continue
+            if raw in cte_names:
+                continue
 
-            # Resolve alias → table
-            resolved = aliases.get(t)
-            if resolved and resolved in right_tables:
-                violations.append(f"{t}.{c}")
+            col_name = _norm(col.name)
+            if not col_name:
+                continue
+
+            resolved = local_aliases.get(raw, raw)
+            # An alias that doesn't belong to THIS select's local FROM/JOIN
+            # is either a correlated outer ref or unrelated — ignore.
+            if raw not in local_aliases:
+                continue
+
+            if raw in right_aliases or resolved in right_real_names:
+                violations.append(f"{raw}.{col_name}")
 
     return violations
 
 
-def _find_violations(
-    tree: exp.Expression,
-    aliases: Dict[str, str],
-    cte_names: Set[str],
-) -> List[str]:
+def _find_violations(tree: exp.Expression) -> List[str]:
     issues: List[str] = []
+    cte_names = _extract_cte_names(tree)
 
-    right_tables = _collect_left_join_right_tables(tree, aliases)
+    for select in tree.find_all(exp.Select):
+        right_aliases, right_real_names = _select_left_join_right_tables(select)
+        if not right_aliases and not right_real_names:
+            continue
 
-    if not right_tables:
-        return issues
+        where = select.args.get("where")
+        if where is None:
+            continue
 
-    for where in tree.find_all(exp.Where):
-        violations = _collect_where_right_table_filters(where.this, right_tables, aliases, cte_names)
+        local = _local_aliases(select)
+        violations = _collect_where_right_table_filters(
+            select,
+            where.this,
+            right_aliases,
+            right_real_names,
+            local,
+            cte_names,
+        )
 
         if violations:
             cols = ", ".join(sorted(set(violations)))
@@ -304,10 +328,7 @@ class LeftJoinThenWhereOnRightTableRule(Rule):
             if not tree:
                 continue
 
-            aliases = extract_aliases(tree)
-            cte_names = _extract_cte_names(tree)
-
-            issues = _find_violations(tree, aliases, cte_names)
+            issues = _find_violations(tree)
 
             for msg in issues:
                 violations.append(

--- a/src/fastssv/rules/joins/visit_occurrence_inner_join_validation.py
+++ b/src/fastssv/rules/joins/visit_occurrence_inner_join_validation.py
@@ -135,24 +135,29 @@ def _is_vo_join(join: exp.Join, aliases: Dict[str, str]) -> bool:
 
 def _join_on_uses_visit_occurrence_id(join: exp.Join) -> bool:
     """True if the JOIN's ON clause references ``visit_occurrence_id`` on
-    at least one side of an equality — i.e. the linkage is actually via
-    the visit-id key.
+    at least one side of an **equality** — i.e. the linkage is actually
+    via the visit-id key.
 
     The rule's premise is "INNER JOIN on visit_occurrence_id drops rows
     where the event's visit_occurrence_id is NULL." That premise only
     applies when the JOIN key is ``visit_occurrence_id``; joining on
     ``person_id`` (or any other column) cannot trigger NULL-driven row
-    loss because those keys aren't nullable on event tables. Without
-    this gate, a perfectly safe ``cohort c JOIN visit_occurrence vo
-    ON c.person_id = vo.person_id`` would be flagged as if visits were
-    being filtered, which is a false positive.
+    loss because those keys aren't nullable on event tables.
+
+    The check is restricted to ``exp.EQ`` nodes so a non-equality
+    predicate that merely *mentions* ``visit_occurrence_id`` —
+    ``ON c.person_id = vo.person_id AND vo.visit_occurrence_id IS NOT NULL``
+    is the canonical FP shape — does not retrigger the warning. An
+    earlier draft walked every Column in the ON clause and reintroduced
+    that false positive class (caught in code review).
     """
     on = join.args.get("on")
     if on is None:
         return False
-    for col in on.find_all(exp.Column):
-        if _norm(col.name) == VISIT_OCCURRENCE_ID:
-            return True
+    for eq in on.find_all(exp.EQ):
+        for side in (eq.this, eq.expression):
+            if isinstance(side, exp.Column) and _norm(side.name) == VISIT_OCCURRENCE_ID:
+                return True
     return False
 
 

--- a/src/fastssv/rules/joins/visit_occurrence_inner_join_validation.py
+++ b/src/fastssv/rules/joins/visit_occurrence_inner_join_validation.py
@@ -133,6 +133,29 @@ def _is_vo_join(join: exp.Join, aliases: Dict[str, str]) -> bool:
     return VISIT_OCCURRENCE in tables
 
 
+def _join_on_uses_visit_occurrence_id(join: exp.Join) -> bool:
+    """True if the JOIN's ON clause references ``visit_occurrence_id`` on
+    at least one side of an equality — i.e. the linkage is actually via
+    the visit-id key.
+
+    The rule's premise is "INNER JOIN on visit_occurrence_id drops rows
+    where the event's visit_occurrence_id is NULL." That premise only
+    applies when the JOIN key is ``visit_occurrence_id``; joining on
+    ``person_id`` (or any other column) cannot trigger NULL-driven row
+    loss because those keys aren't nullable on event tables. Without
+    this gate, a perfectly safe ``cohort c JOIN visit_occurrence vo
+    ON c.person_id = vo.person_id`` would be flagged as if visits were
+    being filtered, which is a false positive.
+    """
+    on = join.args.get("on")
+    if on is None:
+        return False
+    for col in on.find_all(exp.Column):
+        if _norm(col.name) == VISIT_OCCURRENCE_ID:
+            return True
+    return False
+
+
 def _has_intentional_filter(tree: exp.Expression, aliases: Dict[str, str]) -> bool:
     """
     Detect intentional filtering of visit linkage.
@@ -177,6 +200,12 @@ def _find_violations(tree: exp.Expression, aliases: Dict[str, str]) -> List[dict
             continue
 
         if not _is_vo_join(join, aliases):
+            continue
+
+        # Only warn when the JOIN key is actually visit_occurrence_id. A
+        # join on person_id (or any non-VOID key) cannot drop rows due to
+        # NULL visit linkage, so the rule's premise doesn't apply.
+        if not _join_on_uses_visit_occurrence_id(join):
             continue
 
         key = join.sql()

--- a/tests/test_helpers_cte.py
+++ b/tests/test_helpers_cte.py
@@ -59,3 +59,36 @@ def test_extract_aliases_no_cte_unchanged() -> None:
     assert aliases["c"] == "cohort"
     assert aliases["cohort"] == "cohort"
     assert aliases["co"] == "condition_occurrence"
+
+
+def test_has_table_reference_nested_cte_does_not_shadow_outer_ref() -> None:
+    """A CTE defined inside a nested subquery is not visible to the outer
+    query per standard SQL scoping. The previous tree-global ``collect_cte_names``
+    intersection over-approximated visibility — an inner ``WITH cohort AS …``
+    would suppress an outer ``FROM cohort``, silently producing a false
+    negative on every OMOP-table-targeting rule that gates via this helper.
+    """
+    tree = _parse("SELECT * FROM cohort WHERE id IN (WITH cohort AS (SELECT 1 AS id) SELECT id FROM cohort)")
+    assert has_table_reference(tree, "cohort") is True
+
+
+def test_has_table_reference_self_reference_inside_cte_body_resolves_to_omop() -> None:
+    """Inside the CTE's own body, an unqualified reference of the same name
+    refers to the OMOP table, not the CTE itself (standard non-recursive
+    SQL scoping). Confirms the self-reference carve-out in the shadow check."""
+    tree = _parse("WITH cohort AS (SELECT * FROM cohort) SELECT person_id FROM cohort")
+    # The OMOP `cohort` table IS referenced (inside the CTE body).
+    assert has_table_reference(tree, "cohort") is True
+
+
+def test_has_table_reference_outer_with_still_shadows() -> None:
+    """Sanity: the outer-WITH case (the original cohort-shadow scenario
+    that motivated this whole fix) still suppresses correctly."""
+    tree = _parse(
+        "WITH cohort AS (SELECT person_id FROM condition_occurrence) "
+        "SELECT * FROM cohort c JOIN visit_occurrence vo ON c.person_id = vo.person_id"
+    )
+    # Only reference to `cohort` is the outer FROM cohort (shadowed by the WITH).
+    # The CTE body uses condition_occurrence, not cohort.
+    assert has_table_reference(tree, "cohort") is False
+    assert has_table_reference(tree, "condition_occurrence") is True

--- a/tests/test_helpers_cte.py
+++ b/tests/test_helpers_cte.py
@@ -1,0 +1,61 @@
+"""CTE-shadowing semantics for `core.helpers`.
+
+A user CTE named after an OMOP table (e.g. `WITH cohort AS (...)`) must not
+be confused with the actual OMOP table. The helpers below are the central
+chokepoint for OMOP-table-targeting rules; locking in the CTE-aware
+behavior here prevents regressions across the ~50 rules that depend on
+them.
+"""
+
+from __future__ import annotations
+
+import sqlglot
+
+from fastssv.core.helpers import collect_cte_names, extract_aliases, has_table_reference
+
+
+def _parse(sql: str):
+    return sqlglot.parse_one(sql, dialect="postgres")
+
+
+def test_collect_cte_names_basic() -> None:
+    tree = _parse("WITH cohort AS (SELECT 1) SELECT * FROM cohort")
+    assert collect_cte_names(tree) == {"cohort"}
+
+
+def test_collect_cte_names_multiple() -> None:
+    tree = _parse("WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a JOIN b ON 1=1")
+    assert collect_cte_names(tree) == {"a", "b"}
+
+
+def test_collect_cte_names_no_cte() -> None:
+    tree = _parse("SELECT * FROM cohort")
+    assert collect_cte_names(tree) == set()
+
+
+def test_has_table_reference_skips_cte_shadow() -> None:
+    """An unqualified `FROM cohort` that resolves to a CTE in scope is not
+    a reference to the OMOP `cohort` table."""
+    tree = _parse("WITH cohort AS (SELECT 1) SELECT * FROM cohort c")
+    assert has_table_reference(tree, "cohort") is False
+
+
+def test_has_table_reference_keeps_real_table() -> None:
+    tree = _parse("SELECT * FROM cohort c")
+    assert has_table_reference(tree, "cohort") is True
+
+
+def test_has_table_reference_schema_qualified_bypasses_shadow() -> None:
+    """`mydb.cohort` references the OMOP table even when a CTE named
+    `cohort` is in scope (standard SQL scoping)."""
+    tree = _parse("WITH cohort AS (SELECT 1) SELECT * FROM mydb.cohort c")
+    assert has_table_reference(tree, "cohort") is True
+
+
+def test_extract_aliases_no_cte_unchanged() -> None:
+    """Without any CTE, behavior is unchanged."""
+    tree = _parse("SELECT * FROM cohort c JOIN condition_occurrence co ON c.subject_id = co.person_id")
+    aliases = extract_aliases(tree)
+    assert aliases["c"] == "cohort"
+    assert aliases["cohort"] == "cohort"
+    assert aliases["co"] == "condition_occurrence"

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -305,6 +305,7 @@ CANONICAL_FIX_VERBS = (
     "WRAP:",
     "GROUP BY:",
     "QUALIFY:",
+    "RENAME:",
 )
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -330,6 +330,53 @@ class TestStandardConceptMapping:
         errors = validate_standard_concept_mapping(sql)
         assert any("STANDARD concept fields" in e for e in errors)
 
+    def test_suggested_fix_is_schema_qualified_under_cte_shadow(self) -> None:
+        """When a CTE named `concept` is in scope, the rule's suggested_fix
+        must point at `omop.concept` (or call out the shadow), because the
+        bare `JOIN concept c ON …` form would bind to the user's CTE and
+        fail at execution with `column "standard_concept" does not exist`.
+
+        Regression for the second observation in the cohort/CTE-shadow
+        audit: the helper-level gate was fixed earlier, but the rule's
+        per-violation suggested-fix message was still naive about CTE
+        shadowing.
+        """
+        from fastssv.core.registry import get_rule
+
+        rule = get_rule("concept_standardization.standard_concept_enforcement")()
+        sql = """
+        WITH concept AS (SELECT 4112343 AS concept_id UNION ALL SELECT 201826)
+        SELECT co.person_id, concept.concept_id
+        FROM omop.condition_occurrence co
+        JOIN concept ON co.condition_concept_id = concept.concept_id
+        JOIN omop.drug_exposure de ON co.person_id = de.person_id
+        WHERE co.condition_concept_id > 0;
+        """
+        violations = rule.validate(sql)
+        assert len(violations) >= 1
+        fix = violations[0].suggested_fix
+        assert "omop.concept" in fix, fix
+        assert "shadow" in fix.lower(), fix
+
+    def test_suggested_fix_unchanged_without_cte_shadow(self) -> None:
+        """Without a `concept` CTE in scope, the original (non-qualified)
+        suggested_fix message is preserved."""
+        from fastssv.core.registry import get_rule
+
+        rule = get_rule("concept_standardization.standard_concept_enforcement")()
+        sql = """
+        SELECT co.person_id
+        FROM omop.condition_occurrence co
+        JOIN omop.drug_exposure de ON co.person_id = de.person_id
+        WHERE co.condition_concept_id > 0;
+        """
+        violations = rule.validate(sql)
+        assert len(violations) >= 1
+        fix = violations[0].suggested_fix
+        # Suggestion should be the plain `JOIN concept c` form (no schema prefix).
+        assert "omop.concept" not in fix, fix
+        assert "JOIN concept c" in fix, fix
+
 
 class TestJoinPathValidation:
     """Tests for the join-path validation rule, specifically the
@@ -400,6 +447,27 @@ class TestJoinPathValidation:
         violations = self._run_rule(sql)
         assert len(violations) > 0
         assert any("concept" in v.message for v in violations)
+
+    def test_in_subquery_bridge_to_vocab_cte_does_not_fire(self) -> None:
+        """A CTE that wraps the concept table to emit concept_id and is then
+        bridged to a clinical table via `WHERE x_concept_id IN (SELECT
+        concept_id FROM <cte>)` is the canonical Atlas/OHDSI cohort-builder
+        shape. The previous CTE-bridge check only inspected JOIN ON
+        equalities and missed this — emitting false-positive _"Query uses
+        'concept' table but it may not be properly joined…"_ warnings on
+        otherwise-correct concept-set queries."""
+        sql = """
+        WITH lisinopril_concepts AS (
+            SELECT c.concept_id FROM concept c
+            WHERE c.concept_name LIKE 'lisinopril 10 MG Oral Tablet%'
+              AND c.domain_id = 'Drug' AND c.standard_concept = 'S'
+        )
+        SELECT COUNT(DISTINCT de.person_id) AS patient_count
+        FROM drug_exposure de
+        WHERE de.drug_concept_id IN (SELECT concept_id FROM lisinopril_concepts)
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
 
 
 class TestUnmappedConceptHandling:
@@ -3768,6 +3836,45 @@ class TestSchemaValidation:
         violations = self._run_rule(sql)
         assert len(violations) == 0
 
+    def test_alias_collision_across_ctes_does_not_false_positive(self) -> None:
+        """Reusing alias `c` for both `omop.concept` (in one CTE) and the
+        outer-SELECT CTE `cond_occ` must resolve scope-locally, not via the
+        global flat alias dict (which last-write-wins and produces
+        spurious `Column 'person_id' does not exist in table 'concept'`).
+        """
+        sql = """
+        WITH desc_1 AS (
+            SELECT DISTINCT ca.descendant_concept_id AS concept_id
+            FROM omop.concept_ancestor ca
+            JOIN omop.concept c ON c.concept_id = ca.descendant_concept_id
+            WHERE c.standard_concept = 'S'
+        ),
+        cond_occ AS (
+            SELECT person_id, condition_start_date::date AS start_date
+            FROM omop.condition_occurrence co
+            JOIN desc_1 d ON co.condition_concept_id = d.concept_id
+        )
+        SELECT COUNT(DISTINCT c.person_id) AS patient_count
+        FROM cond_occ c
+        WHERE c.start_date IS NOT NULL
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
+
+    def test_datediff_unit_keyword_not_treated_as_column(self) -> None:
+        """sqlglot parses ``DATEDIFF(day, x, y)`` with ``day`` as a Column
+        node. Treating it as a real column reference yielded false-positive
+        ``Column 'day' does not exist in table 'condition_occurrence'``.
+        """
+        sql = """
+        SELECT person_id
+        FROM condition_occurrence
+        GROUP BY person_id
+        HAVING DATEDIFF(day, MIN(condition_start_date), MAX(condition_start_date)) <= 1000
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
+
 
 class TestColumnTypeValidation:
     """Tests for column type validation rule (OMOP_004, 005, 024, 025, 026, 105)."""
@@ -5843,6 +5950,36 @@ class TestVisitOccurrenceInnerJoinValidation:
         """
         violations = self._run_rule(sql)
         assert len(violations) == 0
+
+    def test_omop_043_person_id_join_to_visit_does_not_fire(self) -> None:
+        """INNER JOIN to visit_occurrence on person_id (not visit_occurrence_id)
+        cannot drop rows due to NULL visit linkage — the rule's premise
+        doesn't apply. Regression for the cohort-builder shape
+        `cohort c JOIN visit_occurrence vo ON c.person_id = vo.person_id`."""
+        sql = """
+        WITH cohort AS (
+            SELECT person_id FROM condition_occurrence WHERE condition_concept_id = 4112343
+        )
+        SELECT c.person_id, COUNT(*) AS visits
+        FROM cohort c
+        JOIN visit_occurrence vo ON c.person_id = vo.person_id
+        GROUP BY c.person_id
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
+
+    def test_omop_043_mixed_keys_still_fires(self) -> None:
+        """If the ON clause uses both visit_occurrence_id AND person_id, the
+        VOID linkage is still in play and the warning must fire."""
+        sql = """
+        SELECT co.*
+        FROM condition_occurrence co
+        JOIN visit_occurrence vo
+          ON co.visit_occurrence_id = vo.visit_occurrence_id
+         AND co.person_id = vo.person_id
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
 
 
 class TestDrugEraConceptClassValidation:
@@ -11348,6 +11485,35 @@ class TestCohortClinicalJoinValidation:
         """
         violations = self._run_rule(sql)
         assert len(violations) == 0
+
+    def test_join_022_cte_named_cohort_does_not_false_positive(self) -> None:
+        """A user CTE named ``cohort`` must not be treated as the OMOP table."""
+        sql = """
+        WITH cohort AS (
+            SELECT person_id
+            FROM condition_occurrence
+            WHERE condition_concept_id = 201826
+        )
+        SELECT c.person_id, co.condition_concept_id
+        FROM cohort c
+        JOIN condition_occurrence co ON co.person_id = c.person_id
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 0
+
+    def test_join_022_cte_named_cohort_with_schema_qualified_real_still_fires(self) -> None:
+        """Schema-qualified ``mydb.cohort`` references the OMOP table even when
+        a CTE named ``cohort`` is in scope (standard SQL scoping)."""
+        from fastssv.core.base import Severity
+        sql = """
+        WITH cohort AS (SELECT person_id FROM person)
+        SELECT *
+        FROM mydb.cohort rc
+        JOIN condition_occurrence co ON co.person_id = rc.person_id
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+        assert violations[0].severity == Severity.ERROR
 
 
 class TestEraForbiddenJoinValidation:
@@ -25857,6 +26023,47 @@ class TestLeftJoinThenWhereOnRightTable:
         violations = self._run_rule(sql)
         assert len(violations) == 1
 
+    def test_omop_149_alias_collision_across_ctes_does_not_false_positive(self) -> None:
+        """LEFT JOIN of `cr` lives in one CTE; a sibling CTE INNER-joins the same
+        table re-using the alias `cr` and filters `cr.relationship_id` in its own
+        WHERE. The filter belongs to the INNER-JOIN scope, not the LEFT-JOIN one,
+        so the rule must not fire — regression for scope-local resolution."""
+        sql = """
+        WITH cond_mapped AS (
+            SELECT COALESCE(cr.concept_id_2, cs.concept_id) AS standard_id
+            FROM (SELECT 1 AS concept_id) cs
+            LEFT JOIN omop.concept_relationship cr
+              ON cr.concept_id_1 = cs.concept_id
+             AND cr.relationship_id = 'Maps to'
+             AND cr.invalid_reason IS NULL
+        ),
+        drug_mapped AS (
+            SELECT cr.concept_id_2 AS concept_id
+            FROM (SELECT 2 AS concept_id) ds
+            JOIN omop.concept_relationship cr ON ds.concept_id = cr.concept_id_1
+            WHERE cr.relationship_id = 'Maps to' AND cr.invalid_reason IS NULL
+        )
+        SELECT * FROM cond_mapped cm JOIN drug_mapped dm ON cm.standard_id = dm.concept_id;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 0
+
+    def test_omop_149_left_join_in_inner_cte_still_fires_in_own_scope(self) -> None:
+        """LEFT JOIN + WHERE on its right table inside the SAME CTE must still
+        fire — scope-local refactor is only meant to stop cross-scope leakage,
+        not to silence in-scope violations."""
+        sql = """
+        WITH bad AS (
+            SELECT p.person_id
+            FROM person p
+            LEFT JOIN visit_occurrence vo ON p.person_id = vo.person_id
+            WHERE vo.visit_concept_id = 9201
+        )
+        SELECT * FROM bad;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
 
 # ==============================================================================
 # OMOP_150: Relationship Boolean Comparison Tests
@@ -27022,3 +27229,123 @@ class TestConceptNameLookup:
     def test_filter_on_concept_id_passes(self) -> None:
         sql = "SELECT * FROM concept WHERE concept_id = 201826"
         assert self._run_rule(sql) == []
+
+
+class TestCteShadowsOmopTable:
+    """Tests for anti_patterns.cte_shadows_omop_table — flags CTEs that
+    re-use an OMOP CDM table name (`cohort`, `concept`, `person`, …)."""
+
+    def _run_rule(self, sql: str, dialect: str = "postgres") -> list:
+        from fastssv.core.registry import get_rule
+        rule = get_rule("anti_patterns.cte_shadows_omop_table")()
+        return rule.validate(sql, dialect)
+
+    def test_cte_named_cohort_fires(self) -> None:
+        sql = """
+        WITH cohort AS (SELECT person_id FROM omop.condition_occurrence)
+        SELECT * FROM cohort;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+        assert "cohort" in violations[0].message
+
+    def test_cte_named_concept_fires(self) -> None:
+        sql = """
+        WITH concept AS (SELECT 4112343 AS concept_id)
+        SELECT co.person_id FROM omop.condition_occurrence co
+        JOIN concept ON co.condition_concept_id = concept.concept_id;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+        assert "concept" in violations[0].message
+        assert violations[0].severity == Severity.WARNING
+
+    def test_safe_cte_name_does_not_fire(self) -> None:
+        sql = """
+        WITH my_concepts AS (SELECT 4112343 AS concept_id)
+        SELECT * FROM my_concepts;
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
+
+    def test_no_cte_does_not_fire(self) -> None:
+        sql = "SELECT * FROM omop.condition_occurrence;"
+        violations = self._run_rule(sql)
+        assert violations == []
+
+    def test_multiple_shadows_fire_once_each(self) -> None:
+        sql = """
+        WITH cohort AS (SELECT 1), concept AS (SELECT 2)
+        SELECT * FROM cohort, concept;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 2
+        shadowed = sorted(v.details["omop_table"] for v in violations)
+        assert shadowed == ["cohort", "concept"]
+
+    def test_case_insensitive_match(self) -> None:
+        """`WITH CONCEPT AS …` shadows the OMOP `concept` table regardless of case."""
+        sql = "WITH CONCEPT AS (SELECT 1) SELECT * FROM CONCEPT;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+
+class TestLimitWithoutOrderBy:
+    """Tests for anti_patterns.limit_without_order_by, in particular the
+    scalar-aggregate carve-out that suppresses the warning on queries that
+    provably return exactly one row (where LIMIT N is a no-op)."""
+
+    def _run_rule(self, sql: str, dialect: str = "postgres") -> list:
+        from fastssv.core.registry import get_rule
+        rule = get_rule("anti_patterns.limit_without_order_by")()
+        return rule.validate(sql, dialect)
+
+    def test_scalar_count_with_limit_does_not_fire(self) -> None:
+        """`SELECT COUNT(DISTINCT …) FROM … LIMIT 1000` is the canonical
+        Atlas patient-count shape: the LIMIT is meaningless on a one-row
+        aggregate result and the missing-ORDER-BY warning is a FP."""
+        sql = "SELECT COUNT(DISTINCT person_id) AS patient_count FROM person LIMIT 1000;"
+        assert self._run_rule(sql) == []
+
+    def test_scalar_count_over_cte_does_not_fire(self) -> None:
+        sql = """
+        WITH matching AS (SELECT DISTINCT person_id FROM condition_occurrence)
+        SELECT COUNT(DISTINCT person_id) FROM matching LIMIT 1000;
+        """
+        assert self._run_rule(sql) == []
+
+    def test_aggregate_plus_constant_projection_does_not_fire(self) -> None:
+        """Mixed aggregate + literal projections still produce a single row."""
+        sql = "SELECT COUNT(*) AS c, 1 AS one FROM person LIMIT 100;"
+        assert self._run_rule(sql) == []
+
+    def test_group_by_with_limit_still_fires(self) -> None:
+        """GROUP BY makes the query potentially multi-row — warning stands."""
+        sql = """
+        SELECT condition_concept_id, COUNT(*) AS c
+        FROM condition_occurrence
+        GROUP BY condition_concept_id
+        LIMIT 1000;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+    def test_bare_column_with_limit_still_fires(self) -> None:
+        """A bare column ref in the projection (no aggregate wrap) means the
+        result is multi-row — warning stands."""
+        sql = "SELECT person_id FROM person LIMIT 100;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+    def test_star_with_limit_still_fires(self) -> None:
+        """SELECT * is the textbook missing-ORDER-BY anti-pattern."""
+        sql = "SELECT * FROM person LIMIT 100;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+    def test_aggregate_mixed_with_bare_column_still_fires(self) -> None:
+        """`SELECT MIN(x), p.person_id` without GROUP BY is invalid standard
+        SQL; conservatively we treat it as multi-row and keep the warning."""
+        sql = "SELECT MIN(condition_start_date), person_id FROM condition_occurrence LIMIT 100;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -5981,6 +5981,45 @@ class TestVisitOccurrenceInnerJoinValidation:
         violations = self._run_rule(sql)
         assert len(violations) == 1
 
+    def test_omop_043_void_in_non_equality_predicate_does_not_fire(self) -> None:
+        """Non-equality predicates that merely *mention* visit_occurrence_id
+        (e.g. `IS NOT NULL`, `> 0`, `BETWEEN …`) must not retrigger the
+        warning — the join key is person_id, no NULL-VOID row drop is
+        possible. An earlier draft of the gate walked every Column in the
+        ON clause and re-introduced this false positive class (regression
+        caught in code review)."""
+        sql = """
+        SELECT * FROM cohort c
+        JOIN visit_occurrence vo
+          ON c.person_id = vo.person_id
+         AND vo.visit_occurrence_id IS NOT NULL
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
+
+    def test_omop_043_void_comparison_predicate_does_not_fire(self) -> None:
+        """Same as above but with a comparison predicate rather than IS NOT NULL."""
+        sql = """
+        SELECT * FROM cohort c
+        JOIN visit_occurrence vo
+          ON c.person_id = vo.person_id
+         AND vo.visit_occurrence_id > 0
+        """
+        violations = self._run_rule(sql)
+        assert violations == []
+
+    def test_omop_043_void_equality_to_literal_still_fires(self) -> None:
+        """`vo.visit_occurrence_id = 12345` IS an equality with VOID on one
+        side, so the user is constraining the join through the visit-id
+        key (effectively `INNER JOIN with a specific visit`). The warning's
+        broader intent (did you mean LEFT JOIN?) still applies, so fire."""
+        sql = """
+        SELECT co.* FROM condition_occurrence co
+        JOIN visit_occurrence vo ON co.visit_occurrence_id = 12345
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
 
 class TestDrugEraConceptClassValidation:
     """Tests for drug_era concept class validation rule (OMOP_044)."""
@@ -27347,5 +27386,37 @@ class TestLimitWithoutOrderBy:
         """`SELECT MIN(x), p.person_id` without GROUP BY is invalid standard
         SQL; conservatively we treat it as multi-row and keep the warning."""
         sql = "SELECT MIN(condition_start_date), person_id FROM condition_occurrence LIMIT 100;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+    def test_windowed_aggregate_with_limit_still_fires(self) -> None:
+        """``SUM(x) OVER (…)`` is a window function — it's *per-row*, not
+        row-collapsing, so the SELECT can return many rows and the
+        missing-ORDER-BY warning must fire. sqlglot parses windowed
+        aggregates as ``exp.Window`` wrapping the inner ``exp.AggFunc``,
+        so an earlier draft of ``_is_scalar_aggregate`` mistook the
+        inner aggregate as scalar-agg evidence and silently suppressed
+        the warning (regression caught in code review)."""
+        sql = "SELECT SUM(condition_concept_id) OVER () FROM condition_occurrence LIMIT 10;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+    def test_row_number_window_with_limit_still_fires(self) -> None:
+        """Pure window function (no inner aggregate) still triggers — the
+        per-row semantics are the same and LIMIT is meaningful."""
+        sql = (
+            "SELECT ROW_NUMBER() OVER (ORDER BY condition_concept_id) AS rn "
+            "FROM condition_occurrence LIMIT 10;"
+        )
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+
+    def test_windowed_aggregate_with_partition_still_fires(self) -> None:
+        """``COUNT(*) OVER (PARTITION BY …)`` produces one row per input
+        row, same as the no-frame case."""
+        sql = (
+            "SELECT COUNT(*) OVER (PARTITION BY person_id) AS pc "
+            "FROM condition_occurrence LIMIT 10;"
+        )
         violations = self._run_rule(sql)
         assert len(violations) == 1

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -27271,8 +27271,9 @@ class TestConceptNameLookup:
 
 
 class TestCteShadowsOmopTable:
-    """Tests for anti_patterns.cte_shadows_omop_table — flags CTEs that
-    re-use an OMOP CDM table name (`cohort`, `concept`, `person`, …)."""
+    """Tests for anti_patterns.cte_shadows_omop_table — flags CTEs OR
+    derived-table subquery aliases that re-use an OMOP CDM table name
+    (`cohort`, `concept`, `person`, …)."""
 
     def _run_rule(self, sql: str, dialect: str = "postgres") -> list:
         from fastssv.core.registry import get_rule
@@ -27327,6 +27328,74 @@ class TestCteShadowsOmopTable:
         sql = "WITH CONCEPT AS (SELECT 1) SELECT * FROM CONCEPT;"
         violations = self._run_rule(sql)
         assert len(violations) == 1
+
+    # --- Derived-table subquery shadows --------------------------------
+    # The CTE-only original rule missed `FROM (SELECT …) AS concept` shapes
+    # entirely; those carry the same readability cost (a reader sees
+    # `concept.<col>` and has to trace it back to a derived table rather
+    # than OMOP `concept`). The downstream-fix-breakage harm is CTE-specific
+    # (derived-table aliases are scope-local — sibling FROM items don't see
+    # them), which is why the message for the subquery case omits the
+    # "breaks suggested fixes" framing.
+
+    def test_derived_table_subquery_aliased_to_omop_fires(self) -> None:
+        """`FROM (SELECT …) AS concept` shadows OMOP `concept`."""
+        sql = """
+        SELECT co.person_id
+        FROM condition_occurrence co
+        JOIN (SELECT 4112343 AS concept_id) AS concept
+          ON co.condition_concept_id = concept.concept_id;
+        """
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+        assert violations[0].details["alias_kind"] == "subquery"
+        assert violations[0].details["omop_table"] == "concept"
+        assert violations[0].severity == Severity.WARNING
+
+    def test_subquery_message_drops_downstream_fix_framing(self) -> None:
+        """The subquery message must NOT claim suggested-fix breakage —
+        that harm is CTE-specific. Sibling FROM items don't see derived-
+        table aliases, so a `JOIN concept c` introduced later resolves to
+        OMOP `concept`, not to the subquery."""
+        sql = "SELECT * FROM (SELECT 1 AS concept_id) AS concept;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+        msg = violations[0].message.lower()
+        # Should explicitly describe the subquery case.
+        assert "subquery" in msg
+        # Must not reuse the CTE-specific framing.
+        assert "fixes from other rules" not in msg
+        assert "bind to the cte" not in msg
+
+    def test_scalar_subquery_in_projection_does_not_fire(self) -> None:
+        """A scalar subquery in SELECT (`SELECT (SELECT …) AS concept FROM
+        t`) is not a derived table — sqlglot puts the alias on the outer
+        `exp.Alias` wrapper, not the `Subquery` node itself. Skip those to
+        avoid noise."""
+        sql = "SELECT (SELECT COUNT(*) FROM person) AS concept FROM person;"
+        assert self._run_rule(sql) == []
+
+    def test_anonymous_in_subquery_does_not_fire(self) -> None:
+        """`WHERE x IN (SELECT …)` has no alias on the inner Subquery — nothing
+        to shadow."""
+        sql = (
+            "SELECT * FROM person "
+            "WHERE person_id IN (SELECT person_id FROM condition_occurrence);"
+        )
+        assert self._run_rule(sql) == []
+
+    def test_safe_subquery_alias_does_not_fire(self) -> None:
+        """A derived-table alias that doesn't collide with any OMOP name
+        is a perfectly fine pattern."""
+        sql = "SELECT * FROM (SELECT 4112343 AS concept_id) AS my_concepts;"
+        assert self._run_rule(sql) == []
+
+    def test_subquery_case_insensitive_match(self) -> None:
+        """`FROM (SELECT …) AS CONCEPT` still shadows the OMOP table."""
+        sql = "SELECT * FROM (SELECT 1) AS CONCEPT;"
+        violations = self._run_rule(sql)
+        assert len(violations) == 1
+        assert violations[0].details["omop_table"] == "concept"
 
 
 class TestLimitWithoutOrderBy:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -377,6 +377,37 @@ class TestStandardConceptMapping:
         assert "omop.concept" not in fix, fix
         assert "JOIN concept c" in fix, fix
 
+    def test_suggested_fix_unchanged_when_concept_cte_is_nested_subquery(self) -> None:
+        """A `concept` CTE defined INSIDE a nested subquery (IN / EXISTS /
+        FROM-derived) is lexically out of scope for a JOIN added at the
+        outer SELECT, so the generic `JOIN concept c …` fix is still
+        executable. The shadow-aware branch must NOT fire here.
+
+        Earlier the rule used a tree-global `collect_cte_names(tree)` set
+        which over-approximated visibility and emitted the schema-qualified
+        + shadow-note variant even when the CTE was nested out of scope —
+        flagged in code review. The check now reads only the *top-level*
+        WITH clause (`tree.args["with_"]`).
+        """
+        from fastssv.core.registry import get_rule
+
+        rule = get_rule("concept_standardization.standard_concept_enforcement")()
+        sql = """
+        SELECT co.person_id
+        FROM omop.condition_occurrence co
+        WHERE co.condition_concept_id IN (
+            WITH concept AS (SELECT 4112343 AS concept_id)
+            SELECT concept_id FROM concept
+        );
+        """
+        violations = rule.validate(sql)
+        assert len(violations) >= 1
+        fix = violations[0].suggested_fix
+        # Nested CTE — generic fix is fine, no schema qualification needed.
+        assert "omop.concept" not in fix, fix
+        assert "JOIN concept c" in fix, fix
+        assert "shadow" not in fix.lower(), fix
+
 
 class TestJoinPathValidation:
     """Tests for the join-path validation rule, specifically the


### PR DESCRIPTION
 - Audit-driven false-positive sweep across `joins/`, `data_quality/`, `anti_patterns/`, and `concept_standardization/`, plus one new rule and a small UI MCP improvement (a pill that shows if the MCP is on/off).
<img width="1192" height="539" alt="image" src="https://github.com/user-attachments/assets/0b5bf667-d19c-412e-b634-703a4c4e02ac" />
